### PR TITLE
Update README.md to reflect values passed in env

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,10 @@ cd quickstart/python
 pip install -r requirements.txt
 
 # Fill in your Plaid API keys (client ID, secret, public_key)
-# in server.py to test!
+# to test!
+PLAID_CLIENT_ID=[CLIENT_ID] \
+PLAID_SECRET=[SECRET] \
+PLAID_PUBLIC_KEY=[PUBLIC_KEY] \
 python server.py
 # Go to http://localhost:5000
 ```


### PR DESCRIPTION
eba5b5e changed the Python quickstart to read tokens from the environment, but did not update the README to reflect this change.