### PR TITLE
python, ruby: fail fast if keys are missing

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -13,6 +13,14 @@ app = Flask(__name__)
 PLAID_CLIENT_ID = os.getenv('PLAID_CLIENT_ID')
 PLAID_SECRET = os.getenv('PLAID_SECRET')
 PLAID_PUBLIC_KEY = os.getenv('PLAID_PUBLIC_KEY')
+
+if PLAID_CLIENT_ID is None:
+  raise Exception('Missing `PLAID_CLIENT_ID`, find your client ID and other API keys at https://dashboard.plaid.com/account/keys')
+elif PLAID_SECRET is None:
+  raise Exception('Missing `PLAID_SECRET`, find your secret and other API keys at https://dashboard.plaid.com/account/keys')
+elif PLAID_PUBLIC_KEY is None:
+  raise Exception('Missing `PLAID_PUBLIC_KEY`, find your public_key and other API keys at https://dashboard.plaid.com/account/keys')
+
 # Use 'sandbox' to test with Plaid's Sandbox environment (username: user_good,
 # password: pass_good)
 # Use `development` to test with live users and credentials and `production`

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -4,6 +4,14 @@ require 'plaid'
 
 set :public_folder, File.dirname(__FILE__) + '/public'
 
+if ENV['PLAID_CLIENT_ID'] == nil
+  raise 'Missing `PLAID_CLIENT_ID`, find your client ID and other API keys at https://dashboard.plaid.com/account/keys'
+elsif ENV['PLAID_SECRET'] == nil
+  raise 'Missing `PLAID_SECRET`, find your secret and other API keys at https://dashboard.plaid.com/account/keys'
+elsif ENV['PLAID_PUBLIC_KEY'] == nil
+  raise 'Missing `PLAID_PUBLIC_KEY`, find your public_key and other API keys at https://dashboard.plaid.com/account/keys'
+end
+
 client = Plaid::Client.new(env: :sandbox,
                            client_id: ENV['PLAID_CLIENT_ID'],
                            secret: ENV['PLAID_SECRET'],


### PR DESCRIPTION
- Fail fast if any required API keys are not provided when starting the quickstart app. Otherwise, a developer may start the app without keys and not get any useful feedback.

- [x] Python
- [x] Ruby

This is already done in the Node app.