### PR TITLE
Python 3 compatibility

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,5 @@ Werkzeug==0.11.15
 click==6.7
 itsdangerous==0.24
 requests==2.13.0
-wsgiref==0.1.2
+wsgiref==0.1.2;python_version<'3.0'
 plaid-python>=2.0,<2.1

--- a/python/server.py
+++ b/python/server.py
@@ -19,6 +19,7 @@ PLAID_PUBLIC_KEY = os.getenv('PLAID_PUBLIC_KEY')
 # to go live
 PLAID_ENV = os.getenv('PLAID_ENV', 'sandbox')
 
+
 client = plaid.Client(client_id = PLAID_CLIENT_ID, secret=PLAID_SECRET,
                   public_key=PLAID_PUBLIC_KEY, environment=PLAID_ENV)
 

--- a/python/server.py
+++ b/python/server.py
@@ -19,7 +19,6 @@ PLAID_PUBLIC_KEY = os.getenv('PLAID_PUBLIC_KEY')
 # to go live
 PLAID_ENV = os.getenv('PLAID_ENV', 'sandbox')
 
-
 client = plaid.Client(client_id = PLAID_CLIENT_ID, secret=PLAID_SECRET,
                   public_key=PLAID_PUBLIC_KEY, environment=PLAID_ENV)
 
@@ -36,9 +35,9 @@ def get_access_token():
   global access_token
   public_token = request.form['public_token']
   exchange_response = client.Item.public_token.exchange(public_token)
-  print 'public token: ' + public_token
-  print 'access token: ' + exchange_response['access_token']
-  print 'item ID: ' + exchange_response['item_id']
+  print('public token: ' + public_token)
+  print('access token: ' + exchange_response['access_token'])
+  print('item ID: ' + exchange_response['item_id'])
 
   access_token = exchange_response['access_token']
 


### PR DESCRIPTION
Updated to use Python 3 compatible print statements, and skipped installing wsgiref on Python 3 since it's now in the standard library. This now installs and runs fine for me on Python 3.

This should not break Python 2 compatibility.