### PR TITLE
Updated README.md, clarified server.py

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -7,11 +7,8 @@ git clone https://github.com/plaid/quickstart.git
 cd quickstart/python
 pip install -r requirements.txt
 
-# Fill in your Plaid API keys (client ID, secret, public_key)
-# to test!
-PLAID_CLIENT_ID=[CLIENT_ID] \
-PLAID_SECRET=[SECRET] \
-PLAID_PUBLIC_KEY=[PUBLIC_KEY] \
+# Fill in your API keys (https://dashboard.plaid.com/account/keys) in
+# server.py and then start the sample app:
 python server.py
-# Go to http://localhost:5000
+# Go to http://127.0.0.1:5000
 ```

--- a/python/server.py
+++ b/python/server.py
@@ -10,14 +10,14 @@ app = Flask(__name__)
 
 
 # Fill in your Plaid API keys - https://dashboard.plaid.com/account/keys
-PLAID_CLIENT_ID = os.getenv('PLAID_CLIENT_ID')
-PLAID_SECRET = os.getenv('PLAID_SECRET')
-PLAID_PUBLIC_KEY = os.getenv('PLAID_PUBLIC_KEY')
+PLAID_CLIENT_ID = os.getenv('PLAID_CLIENT_ID', '<YOUR_CLIENT_ID>')
+PLAID_SECRET = os.getenv('PLAID_SECRET', '<YOUR_SECRET>')
+PLAID_PUBLIC_KEY = os.getenv('PLAID_PUBLIC_KEY', '<YOUR_PUBLIC_KEY>')
 # Use 'sandbox' to test with Plaid's Sandbox environment (username: user_good,
 # password: pass_good)
 # Use `development` to test with live users and credentials and `production`
 # to go live
-PLAID_ENV = os.getenv('PLAID_ENV', 'sandbox')
+PLAID_ENV = os.getenv('PLAID_ENV', '<DESIRED_ENVIRONMENT>')
 
 
 client = plaid.Client(client_id = PLAID_CLIENT_ID, secret=PLAID_SECRET,


### PR DESCRIPTION
Clarified where users should input their keys in server.py. Change README.md to match https://plaid.com/docs/quickstart/