### PR TITLE
in Ruby project: use PLAID_ENV variable to define API environment 

### DIFF
--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -4,7 +4,7 @@ require 'plaid'
 
 set :public_folder, File.dirname(__FILE__) + '/public'
 
-client = Plaid::Client.new(env: :sandbox,
+client = Plaid::Client.new(env: ENV['PLAID_ENV'],
                            client_id: ENV['PLAID_CLIENT_ID'],
                            secret: ENV['PLAID_SECRET'],
                            public_key: ENV['PLAID_PUBLIC_KEY'])

--- a/ruby/views/index.erb
+++ b/ruby/views/index.erb
@@ -53,7 +53,7 @@
         var handler = Plaid.create({
             apiVersion: 'v2',
             clientName: 'Plaid Walkthrough Demo',
-            env: 'sandbox',
+            env: '<%= ENV["PLAID_ENV"] %>',
             product: ['transactions'],
             key: '<%= ENV["PLAID_PUBLIC_KEY"] %>',
             onSuccess: function(public_token) {


### PR DESCRIPTION
in Ruby project: use PLAID_ENV variable to define API environment instead of defaulting to sandbox environment.