### PR TITLE
make readme more consistent

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -9,11 +9,10 @@ npm install
 
 # Start the Quickstart with your API keys from the Dashboard
 # https://dashboard.plaid.com/account/keys
-APP_PORT=8000 \
-PLAID_CLIENT_ID='[CLIENT_ID]' \
-PLAID_SECRET='[SECRET]' \
-PLAID_PUBLIC_KEY='[PUBLIC_KEY]' \
-PLAID_ENV=sandbox \
+PLAID_CLIENT_ID='CLIENT_ID' \
+PLAID_SECRET='SECRET' \
+PLAID_PUBLIC_KEY='PUBLIC_KEY' \
+PLAID_ENV='sandbox' \
 node index.js
 # Go to http://localhost:8000
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -14,10 +14,10 @@ pip install -r requirements.txt
 
 # Start the Quickstart with your API keys from the Dashboard
 # https://dashboard.plaid.com/account/keys
-PLAID_CLIENT_ID='[CLIENT_ID]' \
-PLAID_SECRET='[SECRET]' \
-PLAID_PUBLIC_KEY='[PUBLIC_KEY]' \
-PLAID_ENV=sandbox \
+PLAID_CLIENT_ID='CLIENT_ID' \
+PLAID_SECRET='SECRET' \
+PLAID_PUBLIC_KEY='PUBLIC_KEY' \
+PLAID_ENV='sandbox' \
 python server.py
 # Go to http://localhost:5000
 ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -11,10 +11,10 @@ bundle
 
 # Start the Quickstart with your API keys from the Dashboard
 # https://dashboard.plaid.com/account/keys
-PLAID_ENV=sandbox \
-PLAID_CLIENT_ID='[CLIENT_ID]' \
-PLAID_SECRET='[SECRET]' \
-PLAID_PUBLIC_KEY='[PUBLIC_KEY]' \
+PLAID_CLIENT_ID='CLIENT_ID' \
+PLAID_SECRET='SECRET' \
+PLAID_PUBLIC_KEY='PUBLIC_KEY' \
+PLAID_ENV='sandbox' \
 ruby app.rb
 # Go to http://localhost:4567
 ```


### PR DESCRIPTION
- Remove `[` and `]` from API key placeholders
- Ensure quickstart app envvars are in a consistent order and always have single quotes