### PR TITLE
Python 3 compatibility

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,5 @@ Werkzeug==0.11.15
 click==6.7
 itsdangerous==0.24
 requests==2.13.0
-wsgiref==0.1.2
+wsgiref==0.1.2 ; python_version < '3.2'
 plaid-python>=2.3

--- a/python/server.py
+++ b/python/server.py
@@ -123,7 +123,7 @@ def set_access_token():
   return jsonify({'error': None, 'item_id': item['item']['item_id']})
 
 def pretty_print_response(response):
-  print json.dumps(response, indent=2, sort_keys=True)
+  print(json.dumps(response, indent=2, sort_keys=True))
 
 def format_error(e):
   return {'error': {'display_message': e.display_message, 'error_code': e.code, 'error_type': e.type, 'error_message': e.message } }


### PR DESCRIPTION
Hi

An attempt to have the quickstart app compatible with python 2 and 3. 

• Avoid the dependency on `wsgiref` when python > 3.2
• Just the one syntax fix for python 3

Solves https://github.com/plaid/quickstart/issues/37

Quickly tested in both environments using conda, seems to work ok.
