### PR TITLE
Python 3 jsonify on PDF b64encode throws TypeError exception

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -155,7 +155,7 @@ def get_assets():
   return jsonify({
     'error': None,
     'json': asset_report_json,
-    'pdf': base64.b64encode(asset_report_pdf),
+    'pdf': base64.b64encode(asset_report_pdf).decode('utf-8'),
   })
 
 # Retrieve high-level information about an Item


### PR DESCRIPTION
Here's my proposed fix for the server.py Python 3 ```TypeError```, as explained in Issue #53.

For Python 3, the ```bytes``` output of ```base64.b64encode(asset_report_pdf)``` should be decoded to ```str``` before passing the result to ```jsonify```.

My solution is redundant for Python 2.7 (decodes str to str), but because Python 2.7 is end-of-life in 2020, more developers will be using Python 3 over time. I considered using a ```try/except``` on the ```return jsonify({...```, but thought the extra code wasn't worth it, compared to incurring the slight inefficiency of Python 2 string-to-string decoding with this one-line fix. 

Tested with Python 2.7 and 3.7.