### PR TITLE
Add missing `includeInsights` argument to `getAssetReport` method in Node SDK

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -256,8 +256,10 @@ var respondWithAssetReport = (
     });
   }
 
+  var includeInsights = false;
   client.getAssetReport(
     assetReportToken,
+    includeInsights,
     function(error, assetReportGetResponse) {
       if (error != null) {
         prettyPrintResponse(error);


### PR DESCRIPTION
The `getAssetReport` in the Node client takes three non-optional arguments: the string token, a boolean indicating whether to include insights, and the callback. The second boolean argument is missing in the quickstart, which causes the callback to be `undefined` and results in an uncaught promise rejection. 