### PR TITLE
Update countryCode token in view

### DIFF
--- a/ruby/views/index.erb
+++ b/ruby/views/index.erb
@@ -203,7 +203,7 @@
       env: '<%= ENV["PLAID_ENV"] %>',
       product: products,
       key: '<%= ENV["PLAID_PUBLIC_KEY"] %>',
-      key: '<%= ENV["PLAID_COUNTRY_CODES"] || "US,CA,GB,FR,ES" %>'.split(','),
+      countryCodes: '<%= ENV["PLAID_COUNTRY_CODES"] || "US,CA,GB,FR,ES" %>'.split(','),
       // webhook: 'https://your-domain.tld/plaid-webhook',
       onSuccess: function(public_token) {
         $.post('/get_access_token', {


### PR DESCRIPTION
In the ruby quickstart example, the `Plaid.create` javascript function has key twice which breaks the app. Replacing the second `key` variable with `countryCodes` fixes the error.