### PR TITLE
Added the missing `\` in the run command

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -21,7 +21,7 @@ with your Plaid API keys to run the local-server.
 APP_PORT=8000 \
 PLAID_CLIENT_ID=[CLIENT_ID] \
 PLAID_SECRET=[SECRET] \
-PLAID_PUBLIC_KEY=[PUBLIC_KEY]
+PLAID_PUBLIC_KEY=[PUBLIC_KEY] \
 go run server.go
 # Go to http://localhost:8000
 ```


### PR DESCRIPTION
The missing `\` causes the `go run server.go` command to run in a separate shell without the env vars set prior to it.