### PR TITLE
Remove invalid property from python stylesheet

### DIFF
--- a/python/static/style.css
+++ b/python/static/style.css
@@ -146,7 +146,6 @@ Item row
 }
 
 .item-data-row__request-type {
-  background-color
   font-size: 12px;
   color: #02B1F8;
   letter-spacing: 0;


### PR DESCRIPTION
Stylesheet linters will complain that the file has invalid CSS syntax unless this line is removed.