### PR TITLE
Implements OAuth Node support

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -30,21 +30,21 @@ node index.js
 ```
 
 ## The OAuth redirect flow
-Some European institutions require an OAuth redirect authentication flow, where the end user is redirected to the bank’s website or mobile app to authenticate. For this flow, you should provide two additional configuration parameters, PLAID_OAUTH_NONCE and PLAID_OAUTH_REDIRECT_URI.
+Some European institutions require an OAuth redirect authentication flow, where the end user is redirected to the bank’s website or mobile app to authenticate. For this flow, you should provide two additional configuration parameters, `PLAID_OAUTH_NONCE` and `PLAID_OAUTH_REDIRECT_URI`.
 
 ``` bash
-# Start the Quickstart with your API keys from the Dashboard
-# https://dashboard.plaid.com/account/keys
-#
-# PLAID_PRODUCTS is a comma-separated list of products to use when
-# initializing Link.
-#
 # You will need to whitelist the PLAID_OAUTH_REDIRECT_URI for
 # your client ID through the Plaid developer dashboard at
 # https://dashboard.plaid.com/team/api.
 #
 # Set PLAID_OAUTH_NONCE to a unique identifier such as a UUID.
 # The nonce must be at least 16 characters long.
+#
+# Start the Quickstart with your API keys from the Dashboard
+# https://dashboard.plaid.com/account/keys
+#
+# PLAID_PRODUCTS is a comma-separated list of products to use when
+# initializing Link.
 
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \

--- a/node/README.md
+++ b/node/README.md
@@ -1,18 +1,23 @@
-### plaid-node quickstart
+# Quickstart for plaid-node
 
-[Quickstart guide](https://plaid.com/docs/quickstart)
+To run this application locally, first install it and then run either of the flows described below. Additionally, please also refer to the [Quickstart guide](https://plaid.com/docs/quickstart).
 
+## Installing the quickstart app
 ``` bash
 git clone https://github.com/plaid/quickstart.git
 cd quickstart/node
 npm install
+```
 
+## The canonical flow
+``` bash
 # Start the Quickstart with your API keys from the Dashboard
 # https://dashboard.plaid.com/account/keys
 #
-# PLAID_PRODUCTS is a comma-separated list of products to use when initializing
-# Link. Note that this list must contain 'assets' in order for the app to be
-# able to create and retrieve asset reports.
+# PLAID_PRODUCTS is a comma-separated list of products to use when
+# initializing Link. Note that this list must contain 'assets' in
+# order for the app to be able to create and retrieve asset reports.
+
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \
 PLAID_PUBLIC_KEY='PUBLIC_KEY' \
@@ -20,14 +25,25 @@ PLAID_ENV='sandbox' \
 PLAID_PRODUCTS='transactions' \
 PLAID_COUNTRY_CODES='US,CA,GB,FR,ES' \
 node index.js
+
 # Go to http://localhost:8000
 ```
 
+## The OAuth redirect flow
 ``` bash
-# The OAuth redirect flow
+# Start the Quickstart with your API keys from the Dashboard
+# https://dashboard.plaid.com/account/keys
 #
-# You will need to whitelist the OAuth redirect URI for your client ID through
-# the Plaid developer dashboard at https://dashboard.plaid.com/team/api.
+# PLAID_PRODUCTS is a comma-separated list of products to use when
+# initializing Link.
+#
+# You will need to whitelist the PLAID_OAUTH_REDIRECT_URI for
+# your client ID through the Plaid developer dashboard at
+# https://dashboard.plaid.com/team/api.
+#
+# Set PLAID_OAUTH_NONCE to a unique identifier such as a UUID.
+# The nonce must be at least 16 characters long.
+
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \
 PLAID_PUBLIC_KEY='PUBLIC_KEY' \
@@ -37,5 +53,6 @@ PLAID_COUNTRY_CODES='GB' \
 PLAID_OAUTH_REDIRECT_URI='http://localhost:8000/oauth-response.html' \
 PLAID_OAUTH_NONCE='nice-and-long-nonce' \
 node index.js
+
 # Go to http://localhost:8000
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -22,3 +22,20 @@ PLAID_COUNTRY_CODES='US,CA,GB,FR,ES' \
 node index.js
 # Go to http://localhost:8000
 ```
+
+``` bash
+# The OAuth redirect flow
+#
+# You will need to whitelist the OAuth redirect URI for your client ID through
+# the Plaid developer dashboard at https://dashboard.plaid.com/team/api.
+PLAID_CLIENT_ID='CLIENT_ID' \
+PLAID_SECRET='SECRET' \
+PLAID_PUBLIC_KEY='PUBLIC_KEY' \
+PLAID_ENV='sandbox' \
+PLAID_PRODUCTS='transactions' \
+PLAID_COUNTRY_CODES='GB' \
+PLAID_OAUTH_REDIRECT_URI='http://localhost:8000/oauth-response.html' \
+PLAID_OAUTH_NONCE='nice-and-long-nonce' \
+node index.js
+# Go to http://localhost:8000
+```

--- a/node/README.md
+++ b/node/README.md
@@ -30,6 +30,8 @@ node index.js
 ```
 
 ## The OAuth redirect flow
+Some European institutions require an OAuth redirect authentication flow, where the end user is redirected to the bank’s website or mobile app to authenticate. For this flow, you should provide two additional configuration parameters, PLAID_OAUTH_NONCE and PLAID_OAUTH_REDIRECT_URI.
+
 ``` bash
 # Start the Quickstart with your API keys from the Dashboard
 # https://dashboard.plaid.com/account/keys

--- a/node/index.js
+++ b/node/index.js
@@ -30,7 +30,9 @@ var PLAID_COUNTRY_CODES = envvar.string('PLAID_COUNTRY_CODES', 'US,CA');
 // this redirect URI for your client ID through the Plaid developer dashboard
 // at https://dashboard.plaid.com/team/api.
 var PLAID_OAUTH_REDIRECT_URI = envvar.string('PLAID_OAUTH_REDIRECT_URI', '');
-// Set PLAID_OAUTH_NONCE to 'nice-and-long-nonce'
+// Set PLAID_OAUTH_NONCE to a unique identifier such as a UUID for each Link
+// session. The nonce will be used to re-open Link upon completion of the OAuth
+// redirect. The nonce must be at least 16 characters long.
 var PLAID_OAUTH_NONCE = envvar.string('PLAID_OAUTH_NONCE', '');
 
 // We store the access_token in memory - in production, store it in a secure

--- a/node/index.js
+++ b/node/index.js
@@ -25,7 +25,7 @@ var PLAID_COUNTRY_CODES = envvar.string('PLAID_COUNTRY_CODES', 'US,CA');
 // Parameters used for the OAuth redirect Link flow.
 //
 // Set PLAID_OAUTH_REDIRECT_URI to 'http://localhost:8000/oauth-response.html'
-// The OAuth redirect flow requires an end-point on the developer's website
+// The OAuth redirect flow requires an endpoint on the developer's website
 // that the bank website should redirect to. You will need to whitelist
 // this redirect URI for your client ID through the Plaid developer dashboard
 // at https://dashboard.plaid.com/team/api.

--- a/node/index.js
+++ b/node/index.js
@@ -13,7 +13,6 @@ var PLAID_CLIENT_ID = envvar.string('PLAID_CLIENT_ID');
 var PLAID_SECRET = envvar.string('PLAID_SECRET');
 var PLAID_PUBLIC_KEY = envvar.string('PLAID_PUBLIC_KEY');
 var PLAID_ENV = envvar.string('PLAID_ENV', 'sandbox');
-
 // PLAID_PRODUCTS is a comma-separated list of products to use when initializing
 // Link. Note that this list must contain 'assets' in order for the app to be
 // able to create and retrieve asset reports.
@@ -23,6 +22,16 @@ var PLAID_PRODUCTS = envvar.string('PLAID_PRODUCTS', 'transactions');
 // will be able to select institutions from.
 var PLAID_COUNTRY_CODES = envvar.string('PLAID_COUNTRY_CODES', 'US,CA');
 
+// Parameters used for the OAuth redirect Link flow.
+//
+// Set PLAID_OAUTH_REDIRECT_URI to 'http://localhost:8000/oauth-response.html'
+// The OAuth redirect flow requires an end-point on the developer's website
+// that the bank website should redirect to. You will need to whitelist
+// this redirect URI for your client ID through the Plaid developer dashboard
+// at https://dashboard.plaid.com/team/api.
+var PLAID_OAUTH_REDIRECT_URI = envvar.string('PLAID_OAUTH_REDIRECT_URI', '');
+// Set PLAID_OAUTH_NONCE to 'nice-and-long-nonce'
+var PLAID_OAUTH_NONCE = envvar.string('PLAID_OAUTH_NONCE', '');
 
 // We store the access_token in memory - in production, store it in a secure
 // persistent data store
@@ -58,6 +67,21 @@ app.get('/', function(request, response, next) {
     PLAID_ENV: PLAID_ENV,
     PLAID_PRODUCTS: PLAID_PRODUCTS,
     PLAID_COUNTRY_CODES: PLAID_COUNTRY_CODES,
+    PLAID_OAUTH_REDIRECT_URI: PLAID_OAUTH_REDIRECT_URI,
+    PLAID_OAUTH_NONCE: PLAID_OAUTH_NONCE,
+    ITEM_ID: ITEM_ID,
+    ACCESS_TOKEN: ACCESS_TOKEN,
+  });
+});
+
+// This is an end-point defined for the OAuth flow to redirect to.
+app.get('/oauth-response.html', function(request, response, next) {
+  response.render('oauth-response.ejs', {
+    PLAID_PUBLIC_KEY: PLAID_PUBLIC_KEY,
+    PLAID_ENV: PLAID_ENV,
+    PLAID_PRODUCTS: PLAID_PRODUCTS,
+    PLAID_COUNTRY_CODES: PLAID_COUNTRY_CODES,
+    PLAID_OAUTH_NONCE: PLAID_OAUTH_NONCE,
   });
 });
 

--- a/node/index.js
+++ b/node/index.js
@@ -74,7 +74,7 @@ app.get('/', function(request, response, next) {
   });
 });
 
-// This is an end-point defined for the OAuth flow to redirect to.
+// This is an endpoint defined for the OAuth flow to redirect to.
 app.get('/oauth-response.html', function(request, response, next) {
   response.render('oauth-response.ejs', {
     PLAID_PUBLIC_KEY: PLAID_PUBLIC_KEY,

--- a/node/views/index.ejs
+++ b/node/views/index.ejs
@@ -258,11 +258,38 @@
   <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
   <script>
   (function($) {
+    // Handles redirect from the oauth response page for the oauth flow.
+    if (document.referrer != null && document.referrer.includes('http://localhost:8000/oauth-response.html')) {
+      $('#container').fadeOut('fast', function() {
+        $('#item_id').text('<%= ITEM_ID %>');
+        $('#access_token').text('<%= ACCESS_TOKEN %>');
+        $('#intro').hide();
+        $('#app, #steps').fadeIn('slow');
+      });
+    }
+
+
     var products = '<%= PLAID_PRODUCTS %>'.split(',');
     if (products.includes('assets')) {
       $('#assets').show();
     }
 
+    var linkHandlerCommonOptions = {
+      apiVersion: 'v2',
+      clientName: 'Plaid Quickstart',
+      env: '<%= PLAID_ENV %>',
+      product: products,
+      key: '<%= PLAID_PUBLIC_KEY %>',
+      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+    };
+    var oauthRedirectUri = '<%= PLAID_OAUTH_REDIRECT_URI %>';
+    if (oauthRedirectUri != '') {
+      linkHandlerCommonOptions.oauthRedirectUri = oauthRedirectUri;
+    }
+    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>';
+    if (oauthNonce != '') {
+      linkHandlerCommonOptions.oauthNonce = oauthNonce;
+    }
     if (products.includes('payment_initiation')) {
       $('.payment_initiation').show();
       $.post('/set_payment_token', {}, function(data) {
@@ -273,12 +300,7 @@
         // payment token to be generated before the Link handler can be
         // initialized.
         handler = Plaid.create({
-          apiVersion: 'v2',
-          clientName: 'Plaid Quickstart',
-          env: '<%= PLAID_ENV %>',
-          product: products,
-          key: '<%= PLAID_PUBLIC_KEY %>',
-          countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+          ...linkHandlerCommonOptions,
           paymentToken: paymentToken,
           language: 'en',
           onSuccess: function(public_token) {
@@ -301,12 +323,7 @@
       });
     } else {
       var handler = Plaid.create({
-        apiVersion: 'v2',
-        clientName: 'Plaid Quickstart',
-        env: '<%= PLAID_ENV %>',
-        product: products,
-        key: '<%= PLAID_PUBLIC_KEY %>',
-        countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+        ...linkHandlerCommonOptions,
         // webhook: 'https://your-domain.tld/plaid-webhook',
         onSuccess: function(public_token) {
           $.post('/get_access_token', {

--- a/node/views/oauth-response.ejs
+++ b/node/views/oauth-response.ejs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Plaid Quickstart OAuth Response Page Example</title>
+<link rel="stylesheet" href="https://threads.plaid.com/threads.css">
+
+<link rel="stylesheet" type="text/css" href="style.css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+  <script>
+  (function($) {
+    var products = '<%= PLAID_PRODUCTS %>'.split(',');
+    var linkHandlerCommonOptions = {
+      apiVersion: 'v2',
+      clientName: 'Plaid Quickstart',
+      env: '<%= PLAID_ENV %>',
+      product: products,
+      key: '<%= PLAID_PUBLIC_KEY %>',
+      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+    };
+    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>';
+    if (oauthNonce == null || oauthNonce == '') {
+      console.error('oauth_nonce should not be empty');
+    }
+    var oauthStateId = qs('oauth_state_id');
+    if (oauthStateId == null || oauthStateId == '') {
+      console.error('could not parse oauth_state_id from query parameters');
+    }
+    linkHandlerCommonOptions.oauthStateId = oauthStateId;
+    var handler = Plaid.create({
+      ...linkHandlerCommonOptions,
+      oauthNonce: oauthNonce,
+      oauthStateId: oauthStateId,
+      onSuccess: function(public_token) {
+        $.post('/get_access_token', {public_token: public_token}, function(data) {
+          location.href = 'http://localhost:8000';
+        });
+      },
+    });
+    handler.open();
+
+  })(jQuery);
+
+  function qs(key) {
+    key = key.replace(/[*+?^$.\[\]{}()|\\\/]/g, "\\$&"); // escape RegEx meta chars
+    var match = location.search.match(new RegExp("[?&]"+key+"=([^&]+)(&|$)"));
+    return match && decodeURIComponent(match[1].replace(/\+/g, " "));
+  }
+
+  </script>
+</body>
+</html>

--- a/node/views/oauth-response.ejs
+++ b/node/views/oauth-response.ejs
@@ -46,7 +46,6 @@
   })(jQuery);
 
   function qs(key) {
-    key = key.replace(/[*+?^$.\[\]{}()|\\\/]/g, "\\$&"); // escape RegEx meta chars
     var match = location.search.match(new RegExp("[?&]"+key+"=([^&]+)(&|$)"));
     return match && decodeURIComponent(match[1].replace(/\+/g, " "));
   }


### PR DESCRIPTION
- The quickstart already supports the OAuth desktop flow even before this PR. 
- This PR adds support for the OAuth redirect flow (used for mobile web).
- This PR does not add support for the OAuth redirect + webview flow (used for mobile apps).

I tested that this PR works locally for the OAuth flows and does not break the existing classic Plaid Quickstart flow.

Note: The quickstart does not currently demonstrate the webview flow. Handling the webview flow requires defining URLs at the quickstart app to handle Link success and error (https://plaid.com/docs/#communication-between-link-and-your-app). This PR does not add webview support.