### PR TITLE
Remove country codes from most docs

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -18,12 +18,16 @@ go build
 # initializing Link, see https://plaid.com/docs/#item-product-access
 # for complete list.
 
+# PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
+# initializing Link, see plaid.com/docs/faq/#does-plaid-support-international-bank-accounts-
+# for a complete list
+
 APP_PORT=8000 \
 PLAID_CLIENT_ID=[CLIENT_ID] \
 PLAID_SECRET=[SECRET] \
 PLAID_PUBLIC_KEY=[PUBLIC_KEY] \
 PLAID_PRODUCTS=[PRODUCTS] \
-PLAID_COUNTRY_CODES='US,CA,GB,FR,ES,IE,NL' \
+PLAID_COUNTRY_CODES='US' \
 go run server.go
 
 # Go to http://localhost:8000

--- a/go/server.go
+++ b/go/server.go
@@ -15,7 +15,7 @@ func init() {
 		PLAID_PRODUCTS = "transactions"
 	}
 	if PLAID_COUNTRY_CODES == "" {
-		PLAID_COUNTRY_CODES = "US,CA,GB,FR,ES,IE,NL"
+		PLAID_COUNTRY_CODES = "US"
 	}
 }
 

--- a/java/README.md
+++ b/java/README.md
@@ -20,11 +20,15 @@ mvn clean package
 # initializing Link, see https://plaid.com/docs/#item-product-access
 # for complete list.
 
+# PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
+# initializing Link, see plaid.com/docs/faq/#does-plaid-support-international-bank-accounts-
+# for a complete list
+
 PLAID_CLIENT_ID=[CLIENT_ID] \
 PLAID_SECRET=[SECRET] \
 PLAID_PUBLIC_KEY=[PUBLIC_KEY] \
 PLAID_PRODUCTS=[PRODUCTS] \
-PLAID_COUNTRY_CODES='US,CA,GB,FR,ES,IE,NL' \
+PLAID_COUNTRY_CODES='US' \
 java -jar target/quickstart-1.0-SNAPSHOT.jar server config.yml
 
 # Go to http://localhost:8080

--- a/node/README.md
+++ b/node/README.md
@@ -18,12 +18,16 @@ npm install
 # initializing Link, see https://plaid.com/docs/#item-product-access
 # for complete list.
 
+# PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
+# initializing Link, see plaid.com/docs/faq/#does-plaid-support-international-bank-accounts-
+# for a complete list
+
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \
 PLAID_PUBLIC_KEY='PUBLIC_KEY' \
 PLAID_ENV='sandbox' \
 PLAID_PRODUCTS='transactions' \
-PLAID_COUNTRY_CODES='US,CA,GB,FR,ES,IE,NL' \
+PLAID_COUNTRY_CODES='US' \
 node index.js
 
 # Go to http://localhost:8000

--- a/node/index.js
+++ b/node/index.js
@@ -20,7 +20,7 @@ var PLAID_PRODUCTS = envvar.string('PLAID_PRODUCTS', 'transactions');
 
 // PLAID_PRODUCTS is a comma-separated list of countries for which users
 // will be able to select institutions from.
-var PLAID_COUNTRY_CODES = envvar.string('PLAID_COUNTRY_CODES', 'US,CA,GB,FR,ES,IE,NL');
+var PLAID_COUNTRY_CODES = envvar.string('PLAID_COUNTRY_CODES', 'US');
 
 // Parameters used for the OAuth redirect Link flow.
 //

--- a/python/README.md
+++ b/python/README.md
@@ -23,12 +23,16 @@ pip install -r requirements.txt
 # initializing Link, see https://plaid.com/docs/#item-product-access
 # for complete list.
 
+# PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
+# initializing Link, see plaid.com/docs/faq/#does-plaid-support-international-bank-accounts-
+# for a complete list
+
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \
 PLAID_PUBLIC_KEY='PUBLIC_KEY' \
 PLAID_ENV='sandbox' \
 PLAID_PRODUCTS='transactions' \
-PLAID_COUNTRY_CODES='US,CA,GB,FR,ES,IE,NL' \
+PLAID_COUNTRY_CODES='US' \
 python server.py
 
 # Go to http://localhost:5000

--- a/python/server.py
+++ b/python/server.py
@@ -28,7 +28,7 @@ PLAID_PRODUCTS = os.getenv('PLAID_PRODUCTS', 'transactions')
 
 # PLAID_COUNTRY_CODES is a comma-separated list of countries for which users
 # will be able to select institutions from.
-PLAID_COUNTRY_CODES = os.getenv('PLAID_COUNTRY_CODES', 'US,CA,GB,FR,ES,IE,NL')
+PLAID_COUNTRY_CODES = os.getenv('PLAID_COUNTRY_CODES', 'US')
 
 # Parameters used for the OAuth redirect Link flow.
 #

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -19,12 +19,16 @@ bundle
 # initializing Link, see https://plaid.com/docs/#item-product-access
 # for complete list.
 
+# PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
+# initializing Link, see plaid.com/docs/faq/#does-plaid-support-international-bank-accounts-
+# for a complete list
+
 PLAID_CLIENT_ID='CLIENT_ID' \
 PLAID_SECRET='SECRET' \
 PLAID_PUBLIC_KEY='PUBLIC_KEY' \
 PLAID_ENV='sandbox' \
 PLAID_PRODUCTS='transactions' \
-PLAID_COUNTRY_CODES='US,CA,GB,FR,ES,IE,NL' \
+PLAID_COUNTRY_CODES='US' \
 ruby app.rb
 
 # Go to http://localhost:4567

--- a/ruby/views/index.erb
+++ b/ruby/views/index.erb
@@ -277,7 +277,7 @@
       env: '<%= ENV["PLAID_ENV"] %>',
       product: products,
       key: '<%= ENV["PLAID_PUBLIC_KEY"] %>',
-      countryCodes: '<%= ENV["PLAID_COUNTRY_CODES"] || "US,CA,GB,FR,ES,IE,NL" %>'.split(','),
+      countryCodes: '<%= ENV["PLAID_COUNTRY_CODES"] || "US" %>'.split(','),
     };
     var oauthRedirectUri = '<%= ENV["PLAID_OAUTH_REDIRECT_URI"] %>';
     if (oauthRedirectUri != '') {


### PR DESCRIPTION
Clarify integrations by removing non-US country codes from most readmes and sample code.