### PR TITLE
fix ejs templating adding a space at the end

### DIFF
--- a/node/views/index.ejs
+++ b/node/views/index.ejs
@@ -262,15 +262,15 @@
     // Handles redirect from the oauth response page for the oauth flow.
     if (document.referrer != null && document.referrer.includes('http://localhost:8000/oauth-response.html')) {
       $('#container').fadeOut('fast', function() {
-        $('#item_id').text('<%= ITEM_ID %>');
-        $('#access_token').text('<%= ACCESS_TOKEN %>');
+        $('#item_id').text('<%= ITEM_ID %>'.trim());
+        $('#access_token').text('<%= ACCESS_TOKEN %>'.trim());
         $('#intro').hide();
         $('#app, #steps').fadeIn('slow');
       });
     }
 
 
-    var products = '<%= PLAID_PRODUCTS %>'.split(',');
+    var products = '<%= PLAID_PRODUCTS %>'.trim().split(',');
     if (products.includes('assets')) {
       $('#assets').show();
     }
@@ -278,16 +278,16 @@
     var linkHandlerCommonOptions = {
       apiVersion: 'v2',
       clientName: 'Plaid Quickstart',
-      env: '<%= PLAID_ENV %>',
+      env: '<%= PLAID_ENV %>'.trim(),
       product: products,
-      key: '<%= PLAID_PUBLIC_KEY %>',
-      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+      key: '<%= PLAID_PUBLIC_KEY %>'.trim(),
+      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.trim().split(','),
     };
-    var oauthRedirectUri = '<%= PLAID_OAUTH_REDIRECT_URI %>';
+    var oauthRedirectUri = '<%= PLAID_OAUTH_REDIRECT_URI %>'.trim();
     if (oauthRedirectUri != '') {
       linkHandlerCommonOptions.oauthRedirectUri = oauthRedirectUri;
     }
-    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>';
+    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>'.trim();
     if (oauthNonce != '') {
       linkHandlerCommonOptions.oauthNonce = oauthNonce;
     }

--- a/node/views/oauth-response.ejs
+++ b/node/views/oauth-response.ejs
@@ -13,16 +13,16 @@
   <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
   <script>
   (function($) {
-    var products = '<%= PLAID_PRODUCTS %>'.split(',');
+    var products = '<%= PLAID_PRODUCTS %>'.trim().split(',');
     var linkHandlerCommonOptions = {
       apiVersion: 'v2',
       clientName: 'Plaid Quickstart',
-      env: '<%= PLAID_ENV %>',
+      env: '<%= PLAID_ENV %>'.trim(),
       product: products,
-      key: '<%= PLAID_PUBLIC_KEY %>',
-      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.split(','),
+      key: '<%= PLAID_PUBLIC_KEY %>'.trim(),
+      countryCodes: '<%= PLAID_COUNTRY_CODES %>'.trim().split(','),
     };
-    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>';
+    var oauthNonce = '<%= PLAID_OAUTH_NONCE %>'.trim();
     if (oauthNonce == null || oauthNonce == '') {
       console.error('oauth_nonce should not be empty');
     }

--- a/python/templates/index.ejs
+++ b/python/templates/index.ejs
@@ -260,14 +260,14 @@
     // Handles redirect from the oauth response page for the oauth flow.
     if (document.referrer != null && document.referrer.includes('http://localhost:5000/oauth-response.html')) {
       $('#container').fadeOut('fast', function() {
-        $('#item_id').text('{{ item_id }}');
-        $('#access_token').text('{{ access_token }}');
+        $('#item_id').text('{{ item_id }}'.trim();
+        $('#access_token').text('{{ access_token }}'.trim());
         $('#intro').hide();
         $('#app, #steps').fadeIn('slow');
       });
     }
 
-    var products = '{{ plaid_products }}'.split(',');
+    var products = '{{ plaid_products }}'.trim().split(',');
     if (products.includes('assets')) {
       $('#assets').show();
     }
@@ -275,16 +275,16 @@
     var linkHandlerCommonOptions = {
       apiVersion: 'v2',
       clientName: 'Plaid Quickstart',
-      env: '{{ plaid_environment }}',
+      env: '{{ plaid_environment }}'.trim(),
       product: products,
-      key: '{{ plaid_public_key }}',
-      countryCodes: '{{ plaid_country_codes }}'.split(','),
+      key: '{{ plaid_public_key }}'.trim(),
+      countryCodes: '{{ plaid_country_codes }}'.trim().split(','),
     };
-    var oauthRedirectUri = '{{ plaid_oauth_redirect_uri }}';
+    var oauthRedirectUri = '{{ plaid_oauth_redirect_uri }}'.trim();
     if (oauthRedirectUri != '') {
       linkHandlerCommonOptions.oauthRedirectUri = oauthRedirectUri;
     }
-    var oauthNonce = '{{ plaid_oauth_nonce }}';
+    var oauthNonce = '{{ plaid_oauth_nonce }}'.trim();
     if (oauthNonce != '') {
       linkHandlerCommonOptions.oauthNonce = oauthNonce;
     }

--- a/python/templates/index.ejs
+++ b/python/templates/index.ejs
@@ -260,7 +260,7 @@
     // Handles redirect from the oauth response page for the oauth flow.
     if (document.referrer != null && document.referrer.includes('http://localhost:5000/oauth-response.html')) {
       $('#container').fadeOut('fast', function() {
-        $('#item_id').text('{{ item_id }}'.trim();
+        $('#item_id').text('{{ item_id }}'.trim());
         $('#access_token').text('{{ access_token }}'.trim());
         $('#intro').hide();
         $('#app, #steps').fadeIn('slow');

--- a/python/templates/oauth-response.ejs
+++ b/python/templates/oauth-response.ejs
@@ -13,16 +13,16 @@
   <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
   <script>
   (function($) {
-    var products = '{{ plaid_products }}'.split(',');
+    var products = '{{ plaid_products }}'.trim().split(',');
     var linkHandlerCommonOptions = {
       apiVersion: 'v2',
       clientName: 'Plaid Quickstart',
-      env: '{{ plaid_environment }}',
+      env: '{{ plaid_environment }}'.trim(),
       product: products,
-      key: '{{ plaid_public_key }}',
-      countryCodes: '{{ plaid_country_codes }}'.split(','),
+      key: '{{ plaid_public_key }}'.trim(),
+      countryCodes: '{{ plaid_country_codes }}'.trim().split(','),
     };
-    var oauthNonce = '{{ plaid_oauth_nonce }}';
+    var oauthNonce = '{{ plaid_oauth_nonce }}'.trim();
     if (oauthNonce == null || oauthNonce == '') {
       console.error('oauth_nonce should not be empty');
     }


### PR DESCRIPTION
quickstart for node and python did not work on Windows machine, realized it was because all the templated values had a space at the end.

Call trim to remove that space.

Ran quickstart instructions, python and node examples now work.