### PR TITLE
Fix ruby quickstart

### DIFF
--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -264,10 +264,13 @@ post '/set_payment_token' do
     create_recipient_response = client.payment_initiation.create_recipient(
       'Harry Potter',
       'GB33BUKB20201555555555',
-      street:      ['4 Privet Drive'],
-      city:        'Little Whinging',
-      postal_code: '11111',
-      country:     'GB'
+      {
+        street:      ['4 Privet Drive'],
+        city:        'Little Whinging',
+        postal_code: '11111',
+        country:     'GB'
+      },
+      account: '555555',
     )
     recipient_id = create_recipient_response.recipient_id
 

--- a/ruby/views/index.erb
+++ b/ruby/views/index.erb
@@ -274,7 +274,7 @@
     var linkHandlerCommonOptions = {
       apiVersion: 'v2',
       clientName: 'Plaid Quickstart',
-      env: '<%= ENV["PLAID_ENV"] %>',
+      env: '<%= ENV["PLAID_ENV"] || "sandbox" %>',
       product: products,
       key: '<%= ENV["PLAID_PUBLIC_KEY"] %>',
       countryCodes: '<%= ENV["PLAID_COUNTRY_CODES"] || "US" %>'.split(','),


### PR DESCRIPTION
* `client.payment_initiation.create_recipient` expects 4 instead of 3 parameters
* Fallback to `sandbox` env in erb if `ENV["PLAID_ENV"]` is unset.