### PR TITLE
 using maven-resources-plugin to copy html and css files into resources folder

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,67 +80,36 @@
   </dependencies>
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.2</version>
         <executions>
-        <execution>
-        <id>copy-resources</id>
-        <phase>validate</phase>
-        <goals>
-          <goal>copy-resources</goal>
-        </goals>
-        <!-- copy templates and css into resources from root dir-->
-        <configuration>
-          <outputDirectory>src/main/resources</outputDirectory>
-          <resources>
-            <resource>
-              <targetPath>templates</targetPath>
-              <directory>../html/</directory>
-              <filtering>true</filtering>
-            </resource>
-            <resource>
-              <targetPath>static</targetPath>
-              <directory>../static/</directory>
-              <filtering>true</filtering>
-            </resource>
-          </resources>
-        </configuration>
-        </execution>
-        </executions>
-
-       <!-- <executions>
           <execution>
-            <id>copy-html</id>
-            <configuration>
-              <outputDirectory>src/main/resources/templates</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>../html/</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>-->
-        <!--  <execution>
-            <id>copy-css</id>
-            <configuration>
-              <outputDirectory>src/main/resources/static2</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>../static/</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>-->
-        <!--</executions>-->
-
-
+          <id>copy-resources</id>
+          <phase>validate</phase>
+          <goals>
+            <goal>copy-resources</goal>
+          </goals>
+          <!-- copy templates and css into resources from root dir-->
+          <configuration>
+            <outputDirectory>src/main/resources</outputDirectory>
+            <resources>
+              <resource>
+                <targetPath>templates</targetPath>
+                <directory>../html/</directory>
+                <filtering>true</filtering>
+              </resource>
+              <resource>
+                <targetPath>static</targetPath>
+                <directory>../static/</directory>
+                <filtering>true</filtering>
+              </resource>
+            </resources>
+          </configuration>
+          </execution>
+        </executions>
       </plugin>
-
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.4.3</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,6 +80,67 @@
   </dependencies>
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+        <execution>
+        <id>copy-resources</id>
+        <phase>validate</phase>
+        <goals>
+          <goal>copy-resources</goal>
+        </goals>
+        <!-- copy templates and css into resources from root dir-->
+        <configuration>
+          <outputDirectory>src/main/resources</outputDirectory>
+          <resources>
+            <resource>
+              <targetPath>templates</targetPath>
+              <directory>../html/</directory>
+              <filtering>true</filtering>
+            </resource>
+            <resource>
+              <targetPath>static</targetPath>
+              <directory>../static/</directory>
+              <filtering>true</filtering>
+            </resource>
+          </resources>
+        </configuration>
+        </execution>
+        </executions>
+
+       <!-- <executions>
+          <execution>
+            <id>copy-html</id>
+            <configuration>
+              <outputDirectory>src/main/resources/templates</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>../html/</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>-->
+        <!--  <execution>
+            <id>copy-css</id>
+            <configuration>
+              <outputDirectory>src/main/resources/static2</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>../static/</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>-->
+        <!--</executions>-->
+
+
+      </plugin>
+
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.4.3</version>
@@ -134,6 +195,8 @@
         </executions>
       </plugin>
     </plugins>
+
+  
   </build>
   <reporting>
     <plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -86,27 +86,27 @@
         <version>3.0.2</version>
         <executions>
           <execution>
-          <id>copy-resources</id>
-          <phase>validate</phase>
-          <goals>
-            <goal>copy-resources</goal>
-          </goals>
-          <!-- copy templates and css into resources from root dir-->
-          <configuration>
-            <outputDirectory>src/main/resources</outputDirectory>
-            <resources>
-              <resource>
-                <targetPath>templates</targetPath>
-                <directory>../html/</directory>
-                <filtering>true</filtering>
-              </resource>
-              <resource>
-                <targetPath>static</targetPath>
-                <directory>../static/</directory>
-                <filtering>true</filtering>
-              </resource>
-            </resources>
-          </configuration>
+              <id>copy-resources</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <!-- copy templates and css into resources from root dir-->
+              <configuration>
+                <outputDirectory>src/main/resources</outputDirectory>
+                <resources>
+                  <resource>
+                    <targetPath>templates</targetPath>
+                    <directory>../html/</directory>
+                    <filtering>true</filtering>
+                  </resource>
+                  <resource>
+                    <targetPath>static</targetPath>
+                    <directory>../static/</directory>
+                    <filtering>true</filtering>
+                  </resource>
+                </resources>
+              </configuration>
           </execution>
         </executions>
       </plugin>
@@ -164,8 +164,6 @@
         </executions>
       </plugin>
     </plugins>
-
-  
   </build>
   <reporting>
     <plugins>


### PR DESCRIPTION
To fix the issue where the html and css files in the java quickstart example are not rendering correctly, this fix will copy the correct files into the resource folder before building.