### PR TITLE
fix error object doesn't exist when called

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -258,7 +258,7 @@ def get_assets():
       return jsonify({'error': {'display_message': e.display_message, 'error_code': e.code, 'error_type': e.type } })
 
   if asset_report_json == None:
-    return jsonify({'error': {'display_message': 'Timed out when polling for Asset Report', 'error_code': e.code, 'error_type': e.type } })
+    return jsonify({'error': {'display_message': 'Timed out when polling for Asset Report', 'error_code': '', 'error_type': '' } })
 
   asset_report_pdf = None
   try:


### PR DESCRIPTION
Fixes the issue described [here](https://github.com/plaid/quickstart/issues/50). Essentially, there is a bug where the `e` variable does not exist where it is called. Since the error we're throwing in this case is not a Plaid API error but rather a quickstart level error, we don't map any error_code or error_type to the error message.