### PR TITLE
'docker-compose up' uses -d instead of --detach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SUCCESS_MESSAGE := "✅ $(language) quickstart is running on http://localhost:80
 up:
 	$(DOCKER_COMPOSE) \
 		$(DOCKER_COMPOSE_YML) \
-		$@ --build --detach --remove-orphans \
+		$@ --build -d --remove-orphans \
 		$(language)
 	@echo $(SUCCESS_MESSAGE)
 


### PR DESCRIPTION
Makefile fails when attempting "make up" because of syntax related to docker-compose command.
docker-compose version 1.17.1

Usage: up [options] [--scale SERVICE=NUM...] [SERVICE...]

Options:
    -d                         Detached mode: Run containers in the background,
                               print new container names.
                               Incompatible with --abort-on-container-exit.
    --no-color                 Produce monochrome output.
    --no-deps                  Don't start linked services.
    --force-recreate           Recreate containers even if their configuration
                               and image haven't changed.
                               Incompatible with --no-recreate.
    --no-recreate              If containers already exist, don't recreate them.
                               Incompatible with --force-recreate.
    --no-build                 Don't build an image, even if it's missing.
    --no-start                 Don't start the services after creating them.
    --build                    Build images before starting containers.
    --abort-on-container-exit  Stops all containers if any container was stopped.
                               Incompatible with -d.
    -t, --timeout TIMEOUT      Use this timeout in seconds for container shutdown
                               when attached or when containers are already
                               running. (default: 10)
    --remove-orphans           Remove containers for services not
                               defined in the Compose file
    --exit-code-from SERVICE   Return the exit code of the selected service container.
                               Implies --abort-on-container-exit.
    --scale SERVICE=NUM        Scale SERVICE to NUM instances. Overrides the `scale`
                               setting in the Compose file if present.