### PR TITLE
[LP 412] add link errors to landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,18 @@ const App = () => {
       }
       const data = await response.json();
       if (data) {
+        if (data.error != null) {
+          dispatch({
+            type: "SET_STATE",
+            state: {
+              linkToken: null,
+              linkErrorMessage: data.error.error_message,
+              linkErrorType: data.error.error_type,
+              linkErrorCode: data.error.error_code,
+            },
+          });
+          return;
+        }
         dispatch({ type: "SET_STATE", state: { linkToken: data.link_token } });
       }
       localStorage.setItem("link_token", data.link_token); //to use later for Oauth

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,9 +48,7 @@ const App = () => {
             type: "SET_STATE",
             state: {
               linkToken: null,
-              linkErrorMessage: data.error.error_message,
-              linkErrorType: data.error.error_type,
-              linkErrorCode: data.error.error_code,
+              linkTokenError: data.error,
             },
           });
           return;

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -48,9 +48,9 @@ const Header = () => {
           linkToken == null && backend === true ? (
             <Callout warning>
               <div>Unable to fetch link_token:</div>
-              <div>Link Error Code: {linkErrorCode}</div>
-              <div>Link Error Type: {linkErrorType}</div>
-              <div>Link Error Message: {linkErrorMessage}</div>
+              <div>Error Code: {linkErrorCode}</div>
+              <div>Error Type: {linkErrorType}</div>
+              <div>Error Message: {linkErrorMessage}</div>
             </Callout>
           ) : linkToken === "" ? (
             <div className={styles.linkButton}>

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -16,6 +16,9 @@ const Header = () => {
     linkSuccess,
     isItemAccess,
     backend,
+    linkErrorCode,
+    linkErrorMessage,
+    linkErrorType,
   } = useContext(Context);
 
   return (
@@ -35,11 +38,19 @@ const Header = () => {
             to access their accounts via the Plaid API.
           </p>
           {/* message if backend is not running and there is no link token */}
-          {linkToken == null || backend === false ? (
+          {backend === false ? (
             <Callout warning>
               Unable to fetch link_token: please make sure your backend server
               is running and that your .env file has been configured with your
               <code>PLAID_CLIENT_ID</code> and <code>PLAID_SECRET</code>.
+            </Callout>
+          ) : /* message if backend is running and there is no link token */
+          linkToken == null && backend === true ? (
+            <Callout warning>
+              <div>Unable to fetch link_token:</div>
+              <div>Link Error Code: {linkErrorCode}</div>
+              <div>Link Error Type: {linkErrorType}</div>
+              <div>Link Error Message: {linkErrorMessage}</div>
             </Callout>
           ) : linkToken === "" ? (
             <div className={styles.linkButton}>

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -47,9 +47,17 @@ const Header = () => {
           ) : /* message if backend is running and there is no link token */
           linkToken == null && backend === true ? (
             <Callout warning>
-              <div>Unable to fetch link_token:</div>
-              <div>Error Code: {linkErrorCode}</div>
-              <div>Error Type: {linkErrorType}</div>
+              <div>
+                Unable to fetch link_token: please make sure your backend server
+                is running and that your .env file has been configured
+                correctly.
+              </div>
+              <div>
+                Error Code: <code>{linkErrorCode}</code>
+              </div>
+              <div>
+                Error Type: <code>{linkErrorType}</code>{" "}
+              </div>
               <div>Error Message: {linkErrorMessage}</div>
             </Callout>
           ) : linkToken === "" ? (

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -16,9 +16,7 @@ const Header = () => {
     linkSuccess,
     isItemAccess,
     backend,
-    linkErrorCode,
-    linkErrorMessage,
-    linkErrorType,
+    linkTokenError,
   } = useContext(Context);
 
   return (
@@ -38,14 +36,14 @@ const Header = () => {
             to access their accounts via the Plaid API.
           </p>
           {/* message if backend is not running and there is no link token */}
-          {backend === false ? (
+          {!backend ? (
             <Callout warning>
               Unable to fetch link_token: please make sure your backend server
               is running and that your .env file has been configured with your
               <code>PLAID_CLIENT_ID</code> and <code>PLAID_SECRET</code>.
             </Callout>
           ) : /* message if backend is running and there is no link token */
-          linkToken == null && backend === true ? (
+          linkToken == null && backend ? (
             <Callout warning>
               <div>
                 Unable to fetch link_token: please make sure your backend server
@@ -53,12 +51,12 @@ const Header = () => {
                 correctly.
               </div>
               <div>
-                Error Code: <code>{linkErrorCode}</code>
+                Error Code: <code>{linkTokenError.error_code}</code>
               </div>
               <div>
-                Error Type: <code>{linkErrorType}</code>{" "}
+                Error Type: <code>{linkTokenError.error_type}</code>{" "}
               </div>
-              <div>Error Message: {linkErrorMessage}</div>
+              <div>Error Message: {linkTokenError.error_message}</div>
             </Callout>
           ) : linkToken === "" ? (
             <div className={styles.linkButton}>

--- a/frontend/src/Context/index.tsx
+++ b/frontend/src/Context/index.tsx
@@ -9,6 +9,9 @@ interface QuickstartState {
   isError: boolean;
   backend: boolean;
   products: string[];
+  linkErrorType: string;
+  linkErrorCode: string;
+  linkErrorMessage: string;
 }
 
 const initialState: QuickstartState = {
@@ -20,6 +23,9 @@ const initialState: QuickstartState = {
   isError: false,
   backend: true,
   products: ["transactions"],
+  linkErrorType: "",
+  linkErrorCode: "",
+  linkErrorMessage: "",
 };
 
 type QuickstartAction = {

--- a/frontend/src/Context/index.tsx
+++ b/frontend/src/Context/index.tsx
@@ -9,9 +9,11 @@ interface QuickstartState {
   isError: boolean;
   backend: boolean;
   products: string[];
-  linkErrorType: string;
-  linkErrorCode: string;
-  linkErrorMessage: string;
+  linkTokenError: {
+    error_message: string;
+    error_code: string;
+    error_type: string;
+  };
 }
 
 const initialState: QuickstartState = {
@@ -23,9 +25,11 @@ const initialState: QuickstartState = {
   isError: false,
   backend: true,
   products: ["transactions"],
-  linkErrorType: "",
-  linkErrorCode: "",
-  linkErrorMessage: "",
+  linkTokenError: {
+    error_type: "",
+    error_code: "",
+    error_message: "",
+  },
 };
 
 type QuickstartAction = {


### PR DESCRIPTION
Jira ticket:  https://jira.plaid.com/browse/LP-412

This adds information on link token create errors to landing page.  The first message will still appear if the server is not running.  Otherwise if an error occurs in link_create_token, error messages will be displayed.

before: 
![image](https://user-images.githubusercontent.com/77688518/115459699-33de0f00-a1dc-11eb-8ff9-dfd65d3aeb36.png)



after: 

![image](https://user-images.githubusercontent.com/77688518/115475840-66e0cc80-a1f5-11eb-9d65-be87c09e6916.png)

