### PR TITLE
Fix country_codes in python/server.py

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -163,7 +163,7 @@ def create_link_token_for_payment():
         request = LinkTokenCreateRequest(
             products=[Products('payment_initiation')],
             client_name='Plaid Test',
-            country_codes=[CountryCode('GB')],
+            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
             language='en',
             user=LinkTokenCreateRequestUser(
                 client_user_id=str(time.time())
@@ -185,7 +185,7 @@ def create_link_token():
         request = LinkTokenCreateRequest(
             products=products,
             client_name="Plaid Quickstart",
-            country_codes=[CountryCode('US')],
+            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
             language='en',
             user=LinkTokenCreateRequestUser(
                 client_user_id=str(time.time())
@@ -464,7 +464,7 @@ def item():
         response = client.item_get(request)
         request = InstitutionsGetByIdRequest(
             institution_id=response['item']['institution_id'],
-            country_codes=[CountryCode('US')]
+            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES))
         )
         institution_response = client.institutions_get_by_id(request)
         pretty_print_response(response.to_dict())


### PR DESCRIPTION
server.py does not use the `PLAID_COUNTRY_CODES` environment variable for some reason. This was a source of great confusion when I tried to use python to start the backend. The fix is simple so I thought I would propose these changes.