### PR TITLE
clarify testing OAuth in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ PLAID_COUNTRY_CODES=US,CA
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
-# For development, you will need to use an https://
+# For development or production, you will need to use an https:// url
 # If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development.
 # In this case you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=

--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,12 @@ PLAID_PRODUCTS=auth,transactions
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 # Only required for OAuth:
-# Set PLAID_REDIRECT_URI to 'http://localhost:3000'
+# For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000'
 # The OAuth redirect flow requires an endpoint on the developer's website
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
-# The OAuth redirect flow is only testable on the localhost in sandbox.  For development, you will need to use an https://
-# If you are not set up to use localhost with https:// on your system, you can leave the PLAID_REDIRECT_URI blank.
+# For development, you will need to use an https://
+# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development.
+# In this case you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ PLAID_ENV=sandbox
 # PLAID_PRODUCTS is a comma-separated list of products to use when
 # initializing Link, e.g. PLAID_PRODUCTS=auth,transactions.
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-products for a complete list
-# Important: When moving to Production, make sure to update this list with only the products 
+# Important: When moving to Production, make sure to update this list with only the products
 # you plan to use. Otherwise, you may be billed for unneeded products.
 PLAID_PRODUCTS=auth,transactions
 # PLAID_COUNTRY_CODES is a comma-separated list of countries to use when
@@ -21,4 +21,6 @@ PLAID_COUNTRY_CODES=US,CA
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
+# The OAuth redirect flow is only testable on the localhost in sandbox.  For development, you will need to use an https://
+# If you are not set up to use localhost with https:// on your system, you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,6 @@ PLAID_COUNTRY_CODES=US,CA
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
 # For development or production, you will need to use an https:// url
-# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development.
+# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development or production.
 # In this case you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=


### PR DESCRIPTION
Add comments to .env.example to state that development needs https:// and URI may be left blank