### PR TITLE
Fix Go, Node, and Python quickstart servers

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -10,6 +10,7 @@ RUN go build -o quickstart
 FROM gcr.io/distroless/base-debian10
 
 COPY --from=build /opt/src/go/quickstart /
+COPY .env /.env
 
 EXPOSE 8000
 ENTRYPOINT ["/quickstart"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -8,6 +8,7 @@ USER node
 RUN npm install
 
 COPY --chown=node:node ./node/index.js ./
+COPY --chown=node:node ./.env ./
 
 EXPOSE 8000
 ENTRYPOINT ["node"]

--- a/python/server.py
+++ b/python/server.py
@@ -4,7 +4,7 @@ from plaid.exceptions import ApiException
 from plaid.model.payment_amount import PaymentAmount
 from plaid.model.products import Products
 from plaid.model.country_code import CountryCode
-from plaid.model.numbers_bacs_nullable import NumbersBACSNullable
+from plaid.model.recipient_bacs_nullable import RecipientBACSNullable
 from plaid.model.payment_initiation_address import PaymentInitiationAddress
 from plaid.model.payment_initiation_recipient_create_request import PaymentInitiationRecipientCreateRequest
 from plaid.model.payment_initiation_payment_create_request import PaymentInitiationPaymentCreateRequest
@@ -151,7 +151,7 @@ def create_link_token_for_payment():
     try:
         request = PaymentInitiationRecipientCreateRequest(
             name='John Doe',
-            bacs=NumbersBACSNullable(account='26207729', sort_code='560029'),
+            bacs=RecipientBACSNullable(account='26207729', sort_code='560029'),
             address=PaymentInitiationAddress(
                 street=['street name 999'],
                 city='city',


### PR DESCRIPTION
I ran into a few issues when attempting to run the different quickstart applications.

Issues:
* The Dockerfiles for Node and Go did not copy the `.env` files into the container. This broke environment variable loading via dotenv.
* The Python server was using `NumbersBACSNullable` instead of `RecipientBACSNullable`. This caused the `'/api/create_link_token_for_payment' to always fail.