### PR TITLE
Updates the amount used in the payment initiation examples

### DIFF
--- a/go/server.go
+++ b/go/server.go
@@ -197,7 +197,7 @@ func createLinkTokenForPayment(c *gin.Context) {
 	paymentCreateRequest := plaid.NewPaymentInitiationPaymentCreateRequest(
 		paymentRecipientCreateResp.GetRecipientId(),
 		"paymentRef",
-		*plaid.NewPaymentAmount("GBP", 12.34),
+		*plaid.NewPaymentAmount("GBP", 1.34),
 	)
 	paymentCreateResp, _, err := client.PlaidApi.PaymentInitiationPaymentCreate(ctx).PaymentInitiationPaymentCreateRequest(*paymentCreateRequest).Execute()
 	if err != nil {
@@ -597,7 +597,7 @@ func authorizeAndCreateTransfer(ctx context.Context, client *plaid.APIClient, ac
 		accountID,
 		"credit",
 		"ach",
-		"12.34",
+		"1.34",
 		"ppd",
 		*transferAuthorizationCreateUser,
 	)
@@ -614,7 +614,7 @@ func authorizeAndCreateTransfer(ctx context.Context, client *plaid.APIClient, ac
 		authorizationID,
 		"credit",
 		"ach",
-		"12.34",
+		"1.34",
 		"Payment",
 		"ppd",
 		*transferAuthorizationCreateUser,

--- a/java/src/main/java/com/plaid/quickstart/resources/AccessTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AccessTokenResource.java
@@ -82,7 +82,7 @@ public class AccessTokenResource {
         .accountId(accountId)
         .type(TransferType.CREDIT)
         .network(TransferNetwork.ACH)
-        .amount("12.34")
+        .amount("1.34")
         .achClass(ACHClass.PPD)
         .user(user);
 
@@ -99,7 +99,7 @@ public class AccessTokenResource {
         .accountId(accountId)
         .type(TransferType.CREDIT)
         .network(TransferNetwork.ACH)
-        .amount("12.34")
+        .amount("1.34")
         .achClass(ACHClass.PPD)
         .description("Payment")
         .user(user);

--- a/node/index.js
+++ b/node/index.js
@@ -140,7 +140,7 @@ app.post(
           recipient_id: recipientId,
           reference: 'paymentRef',
           amount: {
-            value: 12.34,
+            value: 1.34,
             currency: 'GBP',
           },
         },
@@ -504,7 +504,7 @@ const authorizeAndCreateTransfer = async (accessToken) => {
       account_id: accountId,
       type: 'credit',
       network: 'ach',
-      amount: '12.34',
+      amount: '1.34',
       ach_class: 'ppd',
       user: {
         legal_name: 'FirstName LastName',
@@ -528,7 +528,7 @@ const authorizeAndCreateTransfer = async (accessToken) => {
       authorization_id: authorizationId,
       type: 'credit',
       network: 'ach',
-      amount: '12.34',
+      amount: '1.34',
       description: 'Payment',
       ach_class: 'ppd',
       user: {

--- a/python/server.py
+++ b/python/server.py
@@ -534,7 +534,7 @@ def authorize_and_create_transfer(access_token):
             account_id=account_id,
             type=TransferType('credit'),
             network=TransferNetwork('ach'),
-            amount='12.34',
+            amount='1.34',
             ach_class=ACHClass('ppd'),
             user=TransferUserInRequest(
                 legal_name='FirstName LastName',
@@ -559,7 +559,7 @@ def authorize_and_create_transfer(access_token):
             authorization_id=authorization_id,
             type=TransferType('credit'),
             network=TransferNetwork('ach'),
-            amount='12.34',
+            amount='1.34',
             description='Payment',
             ach_class=ACHClass('ppd'),
             user=TransferUserInRequest(

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -490,7 +490,7 @@ def authorize_and_create_transfer(access_token, client)
       account_id: account_id,
       type: 'credit',
       network: 'ach',
-      amount: '12.34',
+      amount: '1.34',
       ach_class: 'ppd',
       user: {
         legal_name: 'FirstName LastName',
@@ -515,7 +515,7 @@ def authorize_and_create_transfer(access_token, client)
       authorization_id: authorization_id,
       type: 'credit',
       network: 'ach',
-      amount: '12.34',
+      amount: '1.34',
       description: 'Payment',
       ach_class: 'ppd',
       user: {


### PR DESCRIPTION
Without this fix the first atttempt at using the quickstart in the development environment seems doomed to fail if the payment initiation limit is set below GBP12.34. This PR reduces the amount to hopefully reduce the likelihood of needing to contact support to track down the error that occurs if the amount it too high.