### PR TITLE
Add a trailing slash to REDIRECT_URI example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ PLAID_PRODUCTS=auth,transactions
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 # Only required for OAuth:
-# For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000'
+# For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
 # The OAuth redirect flow requires an endpoint on the developer's website
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard


### PR DESCRIPTION
Turns out, our REDIRECT_URI requires a trailing slash if we're redirecting back to the root page. So I added one.