### PR TITLE
Create env

### DIFF
--- a/env
+++ b/env
@@ -1,0 +1,77 @@
+version: "3.4"
+x-environment:
+  &QUICKSTART_ENVIRONMENT # These are read from .env file. The values in the .env file maybe overriden by shell envvars
+  PLAID_CLIENT_ID: ${61e1154134bef600129dc44c}
+  PLAID_SECRET: ${7a0be43c1eef29c769d5104d2a82f4}
+  PLAID_PRODUCTS: ${PLAID_PRODUCTS}
+  PLAID_COUNTRY_CODES: ${PLAID_COUNTRY_CODES}
+  PLAID_REDIRECT_URI: ${PLAID_REDIRECT_URI}
+  PLAID_ENV: ${PLAID_ENV}
+services:
+  go:
+    networks:
+      - "quickstart"
+    depends_on:
+      - "frontend"
+    build:
+      context: .
+      dockerfile: ./go/Dockerfile
+    ports: ["8000:8000"]
+    environment:
+      <<: *QUICKSTART_ENVIRONMENT
+  java:
+    networks:
+      - "quickstart"
+    depends_on:
+      - "frontend"
+    build:
+      context: .
+      dockerfile: ./java/Dockerfile
+    ports: ["8000:8000"]
+    environment:
+      <<: *QUICKSTART_ENVIRONMENT
+  node:
+    networks:
+      - "quickstart"
+    depends_on:
+      - "frontend"
+    build:
+      context: .
+      dockerfile: ./node/Dockerfile
+    ports: ["8000:8000"]
+    environment:
+      <<: *QUICKSTART_ENVIRONMENT
+  python:
+    networks:
+      - "quickstart"
+    depends_on:
+      - "frontend"
+    build:
+      context: .
+      dockerfile: ./python/Dockerfile
+    ports: ["8000:8000"]
+    environment:
+      <<: *QUICKSTART_ENVIRONMENT
+  ruby:
+    networks:
+      - "quickstart"
+    depends_on:
+      - "frontend"
+    build:
+      context: .
+      dockerfile: ./ruby/Dockerfile
+    ports: ["8000:8000"]
+    environment:
+      <<: *QUICKSTART_ENVIRONMENT
+  frontend:
+    environment:
+      - REACT_APP_API_HOST
+    networks:
+      - "quickstart"
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
+    ports: ["3000:3000"]
+networks:
+  quickstart:
+    name: quickstart


### PR DESCRIPTION
ersion: "3.4"
x-environment:
  &QUICKSTART_ENVIRONMENT # These are read from .env file. The values in the .env file maybe overriden by shell envvars
  PLAID_CLIENT_ID: ${PLAID_CLIENT_ID}
  PLAID_SECRET: ${PLAID_SECRET}
  PLAID_PRODUCTS: ${PLAID_PRODUCTS}
  PLAID_COUNTRY_CODES: ${PLAID_COUNTRY_CODES}
  PLAID_REDIRECT_URI: ${PLAID_REDIRECT_URI}
  PLAID_ENV: ${PLAID_ENV}
services:
  go:
    networks:
      - "quickstart"
    depends_on:
      - "frontend"
    build:
      context: .docker run -d -p 80:80 docker/getting-started
      dockerfile: ./go/Dockerfile
    ports: ["8000:8000"]
    environment:
      <<: *QUICKSTART_ENVIRONMENT
  java:
    networks:
      - "quickstart"
    depends_on:
      - "frontend"
    build:
      context: .
      dockerfile: ./java/Dockerfile
    ports: ["8000:8000"]
    environment:
      <<: *QUICKSTART_ENVIRONMENT
  node:
    networks:
      - "quickstart"
    depends_on:
      - "frontend"
    build:
      context: .
      dockerfile: ./node/Dockerfile
    ports: ["8000:8000"]
    environment:
      <<: *QUICKSTART_ENVIRONMENT
  python:
    networks:
      - "quickstart"
    depends_on:
      - "frontend"
    build:
      context: .
      dockerfile: ./python/Dockerfile
    ports: ["8000:8000"]
    environment:
      <<: *QUICKSTART_ENVIRONMENT
  ruby:
    networks:
      - "quickstart"
    depends_on:
      - "frontend"
    build:
      context: .
      dockerfile: ./ruby/Dockerfile
    ports: ["8000:8000"]
    environment:
      <<: *QUICKSTART_ENVIRONMENT
  frontend:
    environment:
      - REACT_APP_API_HOST
    networks:
      - "quickstart"
    build:
      context: .
      dockerfile: ./frontend/Dockerfile
    ports: ["3000:3000"]
networks:
  quickstart:
    name: quickstart