### PR TITLE
Hide Investments if it's not in product list

### DIFF
--- a/frontend/src/Components/ProductTypes/Products.tsx
+++ b/frontend/src/Components/ProductTypes/Products.tsx
@@ -80,16 +80,18 @@ const Products = () => {
         fees."
         transformData={transformBalanceData}
       />
-      <Endpoint
-        endpoint="holdings"
-        name="Investments"
-        categories={investmentsCategories}
-        schema="/investments/holdings/get/"
-        description="Retrieve investment holdings on file with the bank,
+      {products.includes("investments") && (
+        <Endpoint
+          endpoint="holdings"
+          name="Investments"
+          categories={investmentsCategories}
+          schema="/investments/holdings/get/"
+          description="Retrieve investment holdings on file with the bank,
         brokerage, or investment institution. Analyze over-exposure
         to market segments."
-        transformData={transformInvestmentsData}
-      />
+          transformData={transformInvestmentsData}
+        />
+      )}
       {products.includes("transfer") && (
         <Endpoint
           endpoint="transfer"


### PR DESCRIPTION
Just a quick fix to hide the "Investments" entry from our list of endpoints to query if we didn't include it in our list of products when requesting a Link token.