### PR TITLE
Default date to empty string to fix type error

### DIFF
--- a/frontend/src/dataUtilities.ts
+++ b/frontend/src/dataUtilities.ts
@@ -467,7 +467,7 @@ export const transformLiabilitiesData = (data: LiabilitiesGetResponse) => {
     const obj: DataItem = {
       name: account.name,
       type: "credit card",
-      date: credit.last_payment_date,
+      date: credit.last_payment_date ?? "",
       amount: formatCurrency(
         credit.last_payment_amount,
         account.balances.iso_currency_code


### PR DESCRIPTION
Fix for typescript error below:

```
Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.  TS2322

    468 |       name: account.name,
    469 |       type: "credit card",
  > 470 |       date: credit.last_payment_date,
        |       
```^
