### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,12 @@ PLAID_PRODUCTS=auth,transactions
 # initializing Link, e.g. PLAID_COUNTRY_CODES=US,CA.
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
-# Only required for OAuth:
-# For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
 # The OAuth redirect flow requires an endpoint on the developer's website
-# that the bank website should redirect to. You will need to configure
-# this redirect URI for your client ID through the Plaid developer dashboard
-# at https://dashboard.plaid.com/team/api.
+# that the bank website should redirect to.
+# Configuring a PLAID_REDIRECT_URI is optional and not strictly required for the Quickstart to run.
+# For OAuth connections on Sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
+# Important: If you specify a URI here, you MUST add also add it to "Allowed redirect URIs"
+# at https://dashboard.plaid.com/team/api 
 # For development or production, you will need to use an https:// url
 # If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development or production.
 # In this case you can leave the PLAID_REDIRECT_URI blank.


### PR DESCRIPTION
make it more obvious about the PLAID_REDIRECT_URI whitelisting and that it is not required (in response to seeing a number of people making this mistake)