### PR TITLE
add messaging to link create error

### DIFF
--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -51,6 +51,24 @@ const Header = () => {
                 correctly.
               </div>
               <div>
+                If you are on a Windows machine, please ensure that you have
+                cloned the repo with{" "}
+                <InlineLink
+                  href="https://github.com/plaid/quickstart#special-instructions-for-windows"
+                  target="_blank"
+                >
+                  symlinks turned on.
+                </InlineLink>{" "}
+                You can also try checking your{" "}
+                <InlineLink
+                  href="https://dashboard.plaid.com/activity/logs"
+                  target="_blank"
+                >
+                  activity log
+                </InlineLink>{" "}
+                on your Plaid dashboard.
+              </div>
+              <div>
                 Error Code: <code>{linkTokenError.error_code}</code>
               </div>
               <div>


### PR DESCRIPTION
https://jira.plaid.com/browse/DOCS-1008

Add better error messaging on link-create error.  

before:  
![image](https://user-images.githubusercontent.com/77688518/159052405-5fed1c9a-7f1f-4568-b398-6a552c5f2e76.png)


after:

![image](https://user-images.githubusercontent.com/77688518/159052461-571a1ff0-a7e1-4ccf-90fb-ed2fe63b2983.png)
