### PR TITLE
Pin node version in frontend/Dockefile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM node:lts-alpine
+FROM node:16-alpine
 
 # set working directory
 WORKDIR /app


### PR DESCRIPTION
## Problem

Attempting to launch the quickstart tutorial with docker-compose fails because the node version of the frontend's image is not allowed.

The node version of the base docker image (`node:lts-alpine`) is 18.12.0 (as of this writing). The frontend's `package.json` requires a node version of `<17.0.0`.

Because of this, the app fails to launch with `docker-compose`.

> **Note**: if you can run the app fine with `docker-compose`, it is most likely because you older version of `node:lts-alpine` which is running node 17 or earlier

## How to Reproduce

You can follow the following steps to reproduce this issue:

```sh
# Force a pull of the latest version of node:lts-alpine
docker pull node:lts-alpine 

# start the app with python as the backend
make up language=python
```

When I run the above, the frontend image fails to build with this error :

```
 > [quickstart-frontend 5/6] RUN npm install:                                                             
#0 1.147 npm WARN old lockfile                                                                            
#0 1.148 npm WARN old lockfile The package-lock.json file was created with an old version of npm,         
#0 1.148 npm WARN old lockfile so supplemental metadata must be fetched from the registry.                
#0 1.148 npm WARN old lockfile                                                                            
#0 1.148 npm WARN old lockfile This is a one-time fix-up, please be patient...
#0 1.148 npm WARN old lockfile 
#0 36.09 npm notice 
#0 36.09 npm notice New patch version of npm available! 8.19.2 -> 8.19.3
#0 36.09 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v8.19.3>
#0 36.09 npm notice Run `npm install -g npm@8.19.3` to update!
#0 36.09 npm notice 
#0 36.09 npm ERR! code EBADENGINE
#0 36.09 npm ERR! engine Unsupported engine
#0 36.09 npm ERR! engine Not compatible with your version of node/npm: plaid_react_quickstart@0.1.0
#0 36.09 npm ERR! notsup Not compatible with your version of node/npm: plaid_react_quickstart@0.1.0
#0 36.09 npm ERR! notsup Required: {"node":"<17.0.0"}
#0 36.09 npm ERR! notsup Actual:   {"npm":"8.19.2","node":"v18.12.0"}
#0 36.09 
#0 36.09 npm ERR! A complete log of this run can be found in:
#0 36.09 npm ERR!     /root/.npm/_logs/2022-11-05T22_43_47_194Z-debug-0.log
------
failed to solve: executor failed running [/bin/sh -c npm install]: exit code: 1
make: *** [up] Error 17
```

## Fix

The fix I'm proposing is to switch the docker image from `node:lts-alpine` to `node:16-alpine`. With this change, I can successfully start the app with `docker-compose`