### PR TITLE
Make it clear you don't need a redirect URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,16 +27,14 @@ PLAID_PRODUCTS=auth,transactions
 # See https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 
-# PLAID_REDIRECT_URI is an optional Quickstart setting for advanced users
-# and only required for using mobile webviews with OAuth
-# If you do not need to use redirect URIs with the Quickstart, leave this blank
-# For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
+# PLAID_REDIRECT_URI is an optional Quickstart setting for advanced users only
+# If you're not sure if you need to use this field, you can leave it blank
+#
+# If using this field on Sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
 # The OAuth redirect flow requires an endpoint on the developer's website
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard
 # at https://dashboard.plaid.com/team/api.
 # For development or production, you will need to use an https:// url
 # Instructions to create a self-signed certificate for localhost can be found at https://github.com/plaid/quickstart/blob/master/README.md#testing-oauth
-# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth mobile webviews in development or production.
-# In this case you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ PLAID_PRODUCTS=auth,transactions
 # See https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 
-# PLAID_REDIRECT_URI is an optional Quickstart setting for advanced users only
+# PLAID_REDIRECT_URI is optional for this Quickstart application.
 # If you're not sure if you need to use this field, you can leave it blank
 #
 # If using this field on Sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ PLAID_PRODUCTS=auth,transactions
 # See https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 
-# Only required for OAuth:
+# PLAID_REDIRECT_URI is an optional Quickstart setting for advanced users
+# and only required for using mobile webviews with OAuth
+# If you do not need to use redirect URIs with the Quickstart, leave this blank
 # For sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
 # The OAuth redirect flow requires an endpoint on the developer's website
 # that the bank website should redirect to. You will need to configure
@@ -35,6 +37,6 @@ PLAID_COUNTRY_CODES=US,CA
 # at https://dashboard.plaid.com/team/api.
 # For development or production, you will need to use an https:// url
 # Instructions to create a self-signed certificate for localhost can be found at https://github.com/plaid/quickstart/blob/master/README.md#testing-oauth
-# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth in development or production.
+# If you are not set up to use localhost with https:// on your system, you will be unable to test OAuth mobile webviews in development or production.
 # In this case you can leave the PLAID_REDIRECT_URI blank.
 PLAID_REDIRECT_URI=

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ the dashboard: https://dashboard.plaid.com/account/keys
 > NOTE: `.env` files are a convenient local development tool. Never run a production application
 > using an environment file with secrets in it.
 
-## 3. Run the Quickstart
+## 3. Set up your redirect URI
+
+You will also need to register this localhost redirect URI in the
+[Plaid dashboard under Team Settings > API > Allowed redirect URIs][dashboard-api-section].
+
+## 4. Run the Quickstart
 
 There are two ways to run the various language quickstarts in this repository. You can choose to run the
 code directly or you can run it in Docker. If you would like to run the code via Docker, skip to the
@@ -249,18 +254,22 @@ If you get a "You need to update your app" or "institution not supported" error 
 
 If you get the console error "oauth uri does not contain a valid oauth_state_id query parameter", you are attempting to initialize Link with a redirect uri when it is not necessary to do so. The `receivedRedirectUri` should not be set when initializing Link for the first time. It is used when initializing Link for the second time, after returning from the OAuth redirect.
 
-## Testing OAuth
+## Testing OAuth 
 
-Some institutions (primarily in Europe, but a small number in the US) require an OAuth redirect
+Some institutions require an OAuth redirect
 authentication flow, where the end user is redirected to the bank’s website or mobile app to
-authenticate. To test this flow in sandbox, you should set `PLAID_REDIRECT_URI=http://localhost:3000/` in `.env`. You will also need to register this localhost redirect URI in the
-[Plaid dashboard under Team Settings > API > Allowed redirect URIs][dashboard-api-section].
+authenticate. 
 
-To test the OAuth flow in sandbox, choose 'Playtypus OAuth Bank' from the list of financial institutions in Plaid Link.
+To test the OAuth flow in Sandbox, select any institution that uses an OAuth connection with Plaid (a partial list can be found on the [Dashboard OAuth Institutions page](https://dashboard.plaid.com/team/oauth-institutions), or choose 'Playtypus OAuth Bank' from the list of financial institutions in Plaid Link.
 
-### Instructions for using https with localhost
+### Testing OAuth with a redirect URI (optional, advanced)
 
-If you want to test OAuth in development, you need to use https and set `PLAID_REDIRECT_URI=https://localhost:3000/` in `.env`. In order to run your localhost on https, you will need to create a self-signed certificate and add it to the frontend root folder. You can use the following instructions to do this. Note that self-signed certificates should be used for testing purposes only, never for actual deployments.
+To test the OAuth flow in Sandbox with a [redirect URI](https://www.plaid.com/docs/link/oauth/#create-and-register-a-redirect-uri), you should set `PLAID_REDIRECT_URI=http://localhost:3000/` in `.env`. You will also need to register this localhost redirect URI in the
+[Plaid dashboard under Team Settings > API > Allowed redirect URIs][dashboard-api-section]. It is not required to configure a redirect URI in the .env file to use OAuth with the Quickstart. 
+
+#### Instructions for using https with localhost
+
+If you want to test OAuth in development with a redirect URI, you need to use https and set `PLAID_REDIRECT_URI=https://localhost:3000/` in `.env`. In order to run your localhost on https, you will need to create a self-signed certificate and add it to the frontend root folder. You can use the following instructions to do this. Note that self-signed certificates should be used for testing purposes only, never for actual deployments.
 
 In your terminal, change to the frontend folder:
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,7 @@ the dashboard: https://dashboard.plaid.com/account/keys
 > NOTE: `.env` files are a convenient local development tool. Never run a production application
 > using an environment file with secrets in it.
 
-## 3. Set up your redirect URI
-
-You will also need to register this localhost redirect URI in the
-[Plaid dashboard under Team Settings > API > Allowed redirect URIs][dashboard-api-section].
-
-## 4. Run the Quickstart
+## 3. Run the Quickstart
 
 There are two ways to run the various language quickstarts in this repository. You can choose to run the
 code directly or you can run it in Docker. If you would like to run the code via Docker, skip to the

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ authenticate.
 
 To test the OAuth flow in Sandbox, select any institution that uses an OAuth connection with Plaid (a partial list can be found on the [Dashboard OAuth Institutions page](https://dashboard.plaid.com/team/oauth-institutions), or choose 'Playtypus OAuth Bank' from the list of financial institutions in Plaid Link.
 
-### Testing OAuth with a redirect URI (optional, advanced)
+### Testing OAuth with a redirect URI (optional)
 
 To test the OAuth flow in Sandbox with a [redirect URI](https://www.plaid.com/docs/link/oauth/#create-and-register-a-redirect-uri), you should set `PLAID_REDIRECT_URI=http://localhost:3000/` in `.env`. You will also need to register this localhost redirect URI in the
 [Plaid dashboard under Team Settings > API > Allowed redirect URIs][dashboard-api-section]. It is not required to configure a redirect URI in the .env file to use OAuth with the Quickstart. 


### PR DESCRIPTION
The current wording of the quickstart makes it sound like you need to use a redirect URI to test OAuth, but you really don't, especially given the changes we've made in the past ~6 months to use pop-up flows whenever possible. Given how annoying it is to use a redirect URI with the quickstart, especially in production or development, the perceived need to setup redirect uris can be a barrier for entry to developers. This PR (spurred by a recent interaction with a developer on discord) clarifies that you probably don't need to use one. 