### PR TITLE
Organize imports and fix "e" bug

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -1,6 +1,14 @@
 # source /Users/tnappy/node_projects/quickstart/python/bin/activate
 # Read env vars from .env file
-from plaid.exceptions import ApiException
+import base64
+import os
+import datetime as dt
+import json
+import time
+
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+import plaid
 from plaid.model.payment_amount import PaymentAmount
 from plaid.model.payment_amount_currency import PaymentAmountCurrency
 from plaid.model.products import Products
@@ -39,20 +47,7 @@ from plaid.model.ach_class import ACHClass
 from plaid.model.transfer_create_idempotency_key import TransferCreateIdempotencyKey
 from plaid.model.transfer_user_address_in_request import TransferUserAddressInRequest
 from plaid.api import plaid_api
-from flask import Flask
-from flask import render_template
-from flask import request
-from flask import jsonify
-from datetime import datetime
-from datetime import timedelta
-import plaid
-import base64
-import os
-import datetime
-import json
-import time
-from dotenv import load_dotenv
-from werkzeug.wrappers import response
+
 load_dotenv()
 
 
@@ -463,8 +458,8 @@ def get_holdings():
 def get_investments_transactions():
     # Pull transactions for the last 30 days
 
-    start_date = (datetime.datetime.now() - timedelta(days=(30)))
-    end_date = datetime.datetime.now()
+    start_date = (dt.datetime.now() - dt.timedelta(days=(30)))
+    end_date = dt.datetime.now()
     try:
         options = InvestmentsTransactionsGetRequestOptions()
         request = InvestmentsTransactionsGetRequest(

--- a/python/server.py
+++ b/python/server.py
@@ -418,7 +418,7 @@ def get_assets():
                 error_response = format_error(e)
                 return jsonify(error_response)
     if asset_report_json is None:
-        return jsonify({'error': {'status_code': err.status, 'display_message': # type: ignore
+        return jsonify({'error': {'status_code': err.status, 'display_message':
                                   'Timed out when polling for Asset Report', 'error_code': '', 'error_type': ''}})
     try:
         request = AssetReportPDFGetRequest(


### PR DESCRIPTION
Removed unused variable `asset_report_pdf`.
Removed unused imports:

```python
from flask import render_template
from plaid.exceptions import ApiException
from werkzeug.wrappers import response
```

Simplified import and usage of `datetime` functions.

Fixed a bug in `while num_retries_remaining > 0` code block, and the line just following it. In both the `error_response = ...` and `if asset_report_json ... ` blocks, the variable `e` was unbound. This is resolved by declaring `err` as None before the block, then assigning to `err` on each retry. `err` is then used after the `while` block. 

I also put an `else:` before the two lines starting with `error_response = ...` so they would actually run. My assumption is that these were meant to run if the error is anything aside from `PRODUCT_NOT_READY`, whereas currently the `continue` statement makes those lines unreachable.