### PR TITLE
update quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,7 @@ PLAID_ENV=sandbox
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-products for a complete list.
 # Only institutions that support ALL listed products will be displayed in Link.
 # If you don't see the institution you want in Link, remove any products you aren't using.
-# e.g. to show banks that only support credit cards (like AmEx), remove auth.
-# Some products (Transfer, Payment Initiation, Bank Income, Identity Verification) cannot be specified
+# Some products (Payment Initiation, Payroll or Document Income, Identity Verification) cannot be specified
 # Alongside other products.
 # NOTE: The Identity Verification (IDV) and Income APIs have separate Quickstart apps. 
 # For IDV, use https://github.com/plaid/idv-quickstart 

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,15 @@ PLAID_ENV=sandbox
 # see https://plaid.com/docs/api/tokens/#link-token-create-request-products for a complete list.
 # Only institutions that support ALL listed products will be displayed in Link.
 # If you don't see the institution you want in Link, remove any products you aren't using.
+# e.g. to show banks that only support credit cards (like AmEx), remove auth.
+# Some products (Transfer, Payment Initiation, Bank Income, Identity Verification) cannot be specified
+# Alongside other products.
+# NOTE: The Identity Verification (IDV) and Income APIs have separate Quickstart apps. 
+# For IDV, use https://github.com/plaid/idv-quickstart 
+# For Income, use https://github.com/plaid/income-sample
 # Important:
 # When moving to Production, make sure to update this list with only the products
 # you plan to use. Otherwise, you may be billed for unneeded products.
-# NOTE:
-# - 'income_verification' has to be used separately from all other products due to the specific flow.
-# - 'payment_initiation' has to be used separately from all other products due to the specific flow.
 PLAID_PRODUCTS=auth,transactions
 
 # PLAID_COUNTRY_CODES is a comma-separated list of countries to use when

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ If you prefer a non-React frontend platform, or a more minimal backend in one la
 
 For Identity Verification, see the [Identity Verification Quickstart](https://github.com/plaid/idv-quickstart). 
 
+For Income, see the [Income sample app](https://github.com/plaid/income-sample). 
+
+
 ![Plaid quickstart app](/assets/quickstart.jpeg)
 
 ## Table of contents
@@ -243,7 +246,7 @@ If you get a "Connectivity not supported" error after selecting a financial inst
 
 ### "You need to update your app" or "institution not supported"
 
-If you get a "You need to update your app" or "institution not supported" error after selecting a financial institution in Link, you're probably running the Quickstart in Development (or Production) and attempting to link an institution, such as Chase or Wells Fargo, that requires an OAuth-based connection. In order to make OAuth connections to US-based institutions in Development or Production, you must have Production access approval, and certain institutions may also require additional steps. To use this institution, [apply for Production access](https://dashboard.plaid.com/overview/production) and see the [OAuth insitutions page](https://dashboard.plaid.com/team/oauth-institutions) for any other required steps.
+If you get a "You need to update your app" or "institution not supported" error after selecting a financial institution in Link, you're probably running the Quickstart in Development (or Production) and attempting to link an institution, such as Chase or Wells Fargo, that requires an OAuth-based connection. In order to make OAuth connections to US-based institutions in Development or Production, you must have Production access approval, and certain institutions may also require additional approvals before you can be enabled. To use this institution, [apply for Production access](https://dashboard.plaid.com/overview/production) and see the [OAuth insitutions page](https://dashboard.plaid.com/team/oauth-institutions) for any other required steps and to track your OAuth enablement status.
 
 ### "oauth uri does not contain a valid oauth_state_id query parameter"
 
@@ -255,7 +258,7 @@ Some institutions require an OAuth redirect
 authentication flow, where the end user is redirected to the bank’s website or mobile app to
 authenticate. 
 
-To test the OAuth flow in Sandbox, select any institution that uses an OAuth connection with Plaid (a partial list can be found on the [Dashboard OAuth Institutions page](https://dashboard.plaid.com/team/oauth-institutions), or choose 'Playtypus OAuth Bank' from the list of financial institutions in Plaid Link.
+To test the OAuth flow in Sandbox, select any institution that uses an OAuth connection with Plaid (a partial list can be found on the [Dashboard OAuth Institutions page](https://dashboard.plaid.com/team/oauth-institutions)), or choose 'Platypus OAuth Bank' from the list of financial institutions in Plaid Link.
 
 ### Testing OAuth with a redirect URI (optional)
 

--- a/node/index.js
+++ b/node/index.js
@@ -470,7 +470,8 @@ app.get('/api/payment', function (request, response, next) {
     .catch(next);
 });
 
-//TO-DO: This endpoint will be deprecated in the near future
+// This endpoint is still supported but is no longer recommended
+// For Income best practices, see https://github.com/plaid/income-sample instead
 app.get('/api/income/verification/paystubs', function (request, response, next) {
   Promise.resolve()
   .then(async function () {


### PR DESCRIPTION
This has some misc fixes to quickstart wording, but the main thing is to position the income sample app as the income quickstart, since the quickstart has extremely minimal income support (only node, and even there only 1 endpoint, and that endpoint is deprecated). The income sample app is a much more robust and useful onboarding experience. 