### PR TITLE
fix quickstart-428

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,6 @@
   "peerDependencies": {
     "chalk": "^4.1.2"
   },
-  "proxy": "http://127.0.0.1:8000",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
This fixes https://github.com/plaid/quickstart/issues/428 wherein the frontend will not start using node 18 (it works fine with node 16).

This fix is based on a suggestion I found here:

https://github.com/facebook/create-react-app/issues/12304

You'd think that removing this line would break things! But it didn't. I mean, at least not for me. 

Another approach I found that also fixed it was to export the environment variable `DANGEROUSLY_DISABLE_HOST_CHECK=true` as part of the start script, but the optics of that seemed a little bad.

