### PR TITLE
update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE := docker-compose
+DOCKER_COMPOSE := docker compose
 DOCKER_COMPOSE_YML := --file docker-compose.yml
 ifneq ("$(wildcard docker-compose.local.yml)","")
 DOCKER_COMPOSE_YML += --file docker-compose.local.yml


### PR DESCRIPTION
Per https://docs.docker.com/compose/migrate/, `docker-compose` will no longer work for clients using new Docker desktop downloads beginning this month, it must be replaced by `docker compose` in all scripts. 