### PR TITLE
Update .env.example use no quote characters for default redirect URI.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ PLAID_ENV=sandbox
 # If you don't see the institution you want in Link, remove any products you aren't using.
 # Some products (Payment Initiation, Payroll or Document Income, Identity Verification) cannot be specified
 # Alongside other products.
-# NOTE: The Identity Verification (IDV) and Income APIs have separate Quickstart apps. 
-# For IDV, use https://github.com/plaid/idv-quickstart 
+# NOTE: The Identity Verification (IDV) and Income APIs have separate Quickstart apps.
+# For IDV, use https://github.com/plaid/idv-quickstart
 # For Income, use https://github.com/plaid/income-sample
 # Important:
 # When moving to Production, make sure to update this list with only the products
@@ -32,7 +32,7 @@ PLAID_COUNTRY_CODES=US,CA
 # PLAID_REDIRECT_URI is optional for this Quickstart application.
 # If you're not sure if you need to use this field, you can leave it blank
 #
-# If using this field on Sandbox, set PLAID_REDIRECT_URI to 'http://localhost:3000/'
+# If using this field on Sandbox, set PLAID_REDIRECT_URI to http://localhost:3000/ (no quote characters)
 # The OAuth redirect flow requires an endpoint on the developer's website
 # that the bank website should redirect to. You will need to configure
 # this redirect URI for your client ID through the Plaid developer dashboard


### PR DESCRIPTION
When adding in environment variable PLAID_REDIRECT_URI=, I found that quote characters caused a misreference when adding the redirect URI in the Plaid dashboard. 1 PR = 1000 issues, so wanted to ship this update.