### PR TITLE
fix deps

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.1.0
+Flask==3.0.0
 plaid_python==14.0.0
 python-dotenv==0.15.0
-itsdangerous==2.0.1
+itsdangerous==2.1.2
 werkzeug==3.0.1


### PR DESCRIPTION
Soo apparently if you want to accurately test whether the python deps upgrade work you need to actually reinstall them *before* running the python Quickstart. Who knew?