### PR TITLE
update go to v18

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -5,5 +5,5 @@ go 1.12
 require (
 	github.com/gin-gonic/gin v1.6.0
 	github.com/joho/godotenv v1.3.0
-	github.com/plaid/plaid-go/v17 v17.0.0
+	github.com/plaid/plaid-go/v18 v18.0.0
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -220,6 +220,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/plaid/plaid-go/v17 v17.0.0 h1:byLAb7hKw2JQldWZSPIIcQgBAh6SufyULQvbXU55HQg=
 github.com/plaid/plaid-go/v17 v17.0.0/go.mod h1:OnQINLy+PW++58PtJ0aeVP45SeNksIbAJCCiaTuXJcw=
+github.com/plaid/plaid-go/v18 v18.0.0 h1:Gpr8+/DgDDhkUNGHp1N7gkFbXk2vV9FPRk9msPSH7z8=
+github.com/plaid/plaid-go/v18 v18.0.0/go.mod h1:F3o0GI+LVJ9dtwWSsVrEekptDR451hYP5U4kASyPXPU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/go/server.go
+++ b/go/server.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
-	plaid "github.com/plaid/plaid-go/v17/plaid"
+	plaid "github.com/plaid/plaid-go/v18/plaid"
 )
 
 var (
@@ -433,12 +433,11 @@ func transferCreate(c *gin.Context) {
 	ctx := context.Background()
 
 	transferCreateRequest := plaid.NewTransferCreateRequest(
+		accessToken,
+		accountID,
 		authorizationID,
 		"Debit",
 	)
-
-	transferCreateRequest.SetAccessToken(accessToken);
-	transferCreateRequest.SetAccountId(accountID);
 
 	transferCreateResp, _, err := client.PlaidApi.TransferCreate(ctx).TransferCreateRequest(*transferCreateRequest).Execute()
 


### PR DESCRIPTION
version 18 of the go client library (released today) includes breaking changes that impact the quickstart; this brings the quickstart up to use the latest version. 