### PR TITLE
set linkSuccess to true on successful token creation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,7 +55,10 @@ const App = () => {
           });
           return;
         }
-        dispatch({ type: "SET_STATE", state: { linkToken: data.link_token } });
+         dispatch({
+          type: "SET_STATE",
+          state: { linkToken: data.link_token, linkSuccess: true },
+        });
       }
       // Save the link_token to be used later in the Oauth flow.
       localStorage.setItem("link_token", data.link_token);


### PR DESCRIPTION
seems to be a bug in the quickstart, when we create a link successfully we probably need to set linkSuccess to true

this is when we have an access token already stored 