### PR TITLE
Add assets to java

### DIFF
--- a/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
+++ b/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.plaid.quickstart.resources.AccessTokenResource;
 import com.plaid.quickstart.resources.AccountsResource;
+import com.plaid.quickstart.resources.AssetsResource;
 import com.plaid.quickstart.resources.AuthResource;
 import com.plaid.quickstart.resources.BalanceResource;
 import com.plaid.quickstart.resources.HoldingsResource;
@@ -105,6 +106,7 @@ public class QuickstartApplication extends Application<QuickstartConfiguration> 
 
     environment.jersey().register(new AccessTokenResource(plaidClient, plaidProducts));
     environment.jersey().register(new AccountsResource(plaidClient));
+    environment.jersey().register(new AssetsResource(plaidClient));
     environment.jersey().register(new AuthResource(plaidClient));
     environment.jersey().register(new BalanceResource(plaidClient));
     environment.jersey().register(new HoldingsResource(plaidClient));

--- a/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
@@ -59,6 +59,7 @@ public class AssetsResource {
 
     Response<AssetReportGetResponse> assetReportGetResponse = null;
 
+    //In a real integration, we would wait for a webhook rather than polling like this
     for (int i = 0; i < 5; i++){
       assetReportGetResponse = plaidClient.assetReportGet(assetReportGetRequest).execute();
       if (assetReportGetResponse.isSuccessful()){

--- a/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
@@ -39,7 +39,6 @@ public class AssetsResource {
 
   @GET
   public Map getAssetReport() throws IOException {
-
     ArrayList<String> accessTokens = new ArrayList<>();
     accessTokens.add(QuickstartApplication.accessToken);
 
@@ -52,13 +51,10 @@ public class AssetsResource {
       .execute();
 
     String assetReportToken = assetReportCreateResponse.body().getAssetReportToken();
-
-
     AssetReportGetRequest assetReportGetRequest = new AssetReportGetRequest()
       .assetReportToken(assetReportToken);
-
     Response<AssetReportGetResponse> assetReportGetResponse = null;
-
+    
     //In a real integration, we would wait for a webhook rather than polling like this
     for (int i = 0; i < 5; i++){
       assetReportGetResponse = plaidClient.assetReportGet(assetReportGetRequest).execute();
@@ -80,18 +76,15 @@ public class AssetsResource {
     AssetReportPDFGetRequest assetReportPDFGetRequest = new AssetReportPDFGetRequest()
       .assetReportToken(assetReportToken);
 
-        
-      Response<ResponseBody> assetReportPDFGetResponse = plaidClient
-        .assetReportPdfGet(assetReportPDFGetRequest)
-        .execute();
+    Response<ResponseBody> assetReportPDFGetResponse = plaidClient
+      .assetReportPdfGet(assetReportPDFGetRequest)
+      .execute();
 
-      String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponse.body().bytes());
-
-      Map<String, Object> responseMap = new HashMap<>();
-      responseMap.put("json", assetReportGetResponse.body().getReport());
-      responseMap.put("pdf", pdf);
-
-      return responseMap;
+    String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponse.body().bytes());
+    Map<String, Object> responseMap = new HashMap<>();
+    responseMap.put("json", assetReportGetResponse.body().getReport());
+    responseMap.put("pdf", pdf);
+    return responseMap;
 
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
@@ -1,0 +1,96 @@
+package com.plaid.quickstart.resources;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.plaid.client.request.PlaidApi;
+import com.plaid.client.model.AssetReportCreateRequest;
+import com.plaid.client.model.AssetReportCreateResponse;
+import com.plaid.client.model.AssetReportGetRequest;
+import com.plaid.client.model.AssetReportGetResponse;
+import com.plaid.client.model.AssetReportPDFGetRequest;
+import com.plaid.quickstart.QuickstartApplication;
+import com.plaid.client.model.PlaidError;
+import com.plaid.client.model.PlaidErrorType;
+import okhttp3.ResponseBody;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Base64;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import retrofit2.Response;
+import com.google.gson.Gson;
+import jersey.repackaged.com.google.common.base.Throwables;
+
+@Path("/assets")
+@Produces(MediaType.APPLICATION_JSON)
+public class AssetsResource {
+  private final PlaidApi plaidClient;
+
+  public AssetsResource(PlaidApi plaidClient) {
+    this.plaidClient = plaidClient;
+  }
+
+  @GET
+  public Map getAssetReport() throws IOException {
+
+    ArrayList<String> accessTokens = new ArrayList<>();
+    accessTokens.add(QuickstartApplication.accessToken);
+
+    AssetReportCreateRequest assetReportCreateRequest = new AssetReportCreateRequest()
+      .accessTokens(accessTokens)
+      .daysRequested(10);
+
+    Response<AssetReportCreateResponse> assetReportCreateResponse = plaidClient
+      .assetReportCreate(assetReportCreateRequest)
+      .execute();
+
+    String assetReportToken = assetReportCreateResponse.body().getAssetReportToken();
+
+
+    AssetReportGetRequest assetReportGetRequest = new AssetReportGetRequest()
+      .assetReportToken(assetReportToken);
+
+    Response<AssetReportGetResponse> assetReportGetResponse = null;
+
+    for (int i = 0; i < 5; i++){
+      assetReportGetResponse = plaidClient.assetReportGet(assetReportGetRequest).execute();
+      if (assetReportGetResponse.isSuccessful()){
+        break;
+      } else {
+        try {
+          Gson gson = new Gson();
+          PlaidError error = gson.fromJson(assetReportGetResponse.errorBody().string(), PlaidError.class);
+          error.getErrorType().equals(PlaidErrorType.ASSET_REPORT_ERROR);
+          error.getErrorCode().equals("PRODUCT_NOT_READY");
+          Thread.sleep(5000);
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    }
+
+    AssetReportPDFGetRequest assetReportPDFGetRequest = new AssetReportPDFGetRequest()
+      .assetReportToken(assetReportToken);
+
+        
+      Response<ResponseBody> assetReportPDFGetResponse = plaidClient
+        .assetReportPdfGet(assetReportPDFGetRequest)
+        .execute();
+
+      String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponse.body().bytes());
+
+      Map<String, Object> responseMap = new HashMap<>();
+      responseMap.put("json", assetReportGetResponse.body().getReport());
+      responseMap.put("pdf", pdf);
+
+      return responseMap;
+
+  }
+}

--- a/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
@@ -33,28 +33,28 @@ public class StatementsResource {
   @GET
   public Map statementsList() throws IOException {
 
-      StatementsListRequest statementsListRequest = new StatementsListRequest()
-        .accessToken(QuickstartApplication.accessToken);
+    StatementsListRequest statementsListRequest = new StatementsListRequest()
+      .accessToken(QuickstartApplication.accessToken);
 
-      Response<StatementsListResponse> statementsListResponse = plaidClient
-        .statementsList(statementsListRequest)
-        .execute();
+    Response<StatementsListResponse> statementsListResponse = plaidClient
+      .statementsList(statementsListRequest)
+      .execute();
 
-      StatementsDownloadRequest statementsDownloadRequest = new StatementsDownloadRequest()
-        .accessToken(QuickstartApplication.accessToken)
-        .statementId(statementsListResponse.body().getAccounts().get(0).getStatements().get(0).getStatementId());
-        
-      Response<ResponseBody> statementsDownloadResponse = plaidClient
-        .statementsDownload(statementsDownloadRequest)
-        .execute();
+    StatementsDownloadRequest statementsDownloadRequest = new StatementsDownloadRequest()
+      .accessToken(QuickstartApplication.accessToken)
+      .statementId(statementsListResponse.body().getAccounts().get(0).getStatements().get(0).getStatementId());
+      
+    Response<ResponseBody> statementsDownloadResponse = plaidClient
+      .statementsDownload(statementsDownloadRequest)
+      .execute();
 
-      String pdf = Base64.getEncoder().encodeToString(statementsDownloadResponse.body().bytes());
+    String pdf = Base64.getEncoder().encodeToString(statementsDownloadResponse.body().bytes());
 
-      Map<String, Object> responseMap = new HashMap<>();
-      responseMap.put("json", statementsListResponse.body());
-      responseMap.put("pdf", pdf);
+    Map<String, Object> responseMap = new HashMap<>();
+    responseMap.put("json", statementsListResponse.body());
+    responseMap.put("pdf", pdf);
 
-      return responseMap;
+    return responseMap;
 
   }
 }


### PR DESCRIPTION
For reasons unbeknownst to me, we never added asset reports to the java quickstart.

Once I figured out how to handle returning PDFs in Java (which I needed to do for the Statements quickstart) it was pretty easy to do this, so I did it. 

This also includes a little whitespace cleanup for the statements addition, which (while working on this) I realized was indented too far. 