### PR TITLE
Improve Quickstart behavior when pressing /transactions/sync very fast (fixes DOCS-1622)

### DIFF
--- a/go/server.go
+++ b/go/server.go
@@ -118,7 +118,6 @@ func main() {
 	r.GET("/api/signal_evaluate", signalEvaluate)
 	r.GET("/api/statements", statements)
 
-
 	err := r.Run(":" + APP_PORT)
 	if err != nil {
 		panic("unable to start server")
@@ -217,8 +216,8 @@ func createLinkTokenForPayment(c *gin.Context) {
 	fmt.Println("payment id: " + paymentID)
 
 	// Create the link_token
-	linkTokenCreateReqPaymentInitiation := plaid.NewLinkTokenCreateRequestPaymentInitiation();
-	linkTokenCreateReqPaymentInitiation.SetPaymentId(paymentID);
+	linkTokenCreateReqPaymentInitiation := plaid.NewLinkTokenCreateRequestPaymentInitiation()
+	linkTokenCreateReqPaymentInitiation.SetPaymentId(paymentID)
 	linkToken, err := linkTokenCreate(linkTokenCreateReqPaymentInitiation)
 	if err != nil {
 		renderError(c, err)
@@ -352,14 +351,27 @@ func transactions(c *gin.Context) {
 			return
 		}
 
+		// Update cursor to the next cursor
+		nextCursor := resp.GetNextCursor()
+		cursor = &nextCursor
+
+		// If no transactions are available yet, wait and poll the endpoint.
+		// Normally, we would listen for a webhook before calling
+		// /transactions/sync instead of polling, but the Quickstart doesn't
+		// support webhooks. For a webhook example, see
+		// https://github.com/plaid/tutorial-resources or
+		// https://github.com/plaid/pattern
+
+		if *cursor == "" {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
 		// Add this page of results
 		added = append(added, resp.GetAdded()...)
 		modified = append(modified, resp.GetModified()...)
 		removed = append(removed, resp.GetRemoved()...)
 		hasMore = resp.GetHasMore()
-		// Update cursor to the next cursor
-		nextCursor := resp.GetNextCursor()
-		cursor = &nextCursor
 	}
 
 	sort.Slice(added, func(i, j int) bool {
@@ -419,7 +431,7 @@ func transferAuthorize(c *gin.Context) {
 		"1.00",
 		*transferAuthorizationCreateUser)
 
-	transferAuthorizationCreateRequest.SetAchClass(*ACHClass);
+	transferAuthorizationCreateRequest.SetAchClass(*ACHClass)
 	transferAuthorizationCreateResp, _, err := client.PlaidApi.TransferAuthorizationCreate(ctx).TransferAuthorizationCreateRequest(*transferAuthorizationCreateRequest).Execute()
 
 	if err != nil {
@@ -603,7 +615,7 @@ func linkTokenCreate(
 		"en",
 		countryCodes,
 		user,
-	)		
+	)
 
 	products := convertProducts(strings.Split(PLAID_PRODUCTS, ","))
 	if paymentInitiation != nil {
@@ -614,11 +626,11 @@ func linkTokenCreate(
 		request.SetProducts(products)
 	}
 
-	if (containsProduct(products, plaid.PRODUCTS_STATEMENTS)) {
-		statementConfig := plaid.NewLinkTokenCreateRequestStatements();
-		statementConfig.SetStartDate(time.Now().Local().Add(-30 * 24 * time.Hour).Format("2006-01-02"));
-		statementConfig.SetEndDate(time.Now().Local().Format("2006-01-02"));
-		request.SetStatements(*statementConfig);
+	if containsProduct(products, plaid.PRODUCTS_STATEMENTS) {
+		statementConfig := plaid.NewLinkTokenCreateRequestStatements()
+		statementConfig.SetStartDate(time.Now().Local().Add(-30 * 24 * time.Hour).Format("2006-01-02"))
+		statementConfig.SetEndDate(time.Now().Local().Format("2006-01-02"))
+		request.SetStatements(*statementConfig)
 	}
 
 	if redirectURI != "" {

--- a/go/server.go
+++ b/go/server.go
@@ -356,8 +356,7 @@ func transactions(c *gin.Context) {
 		cursor = &nextCursor
 
 		// If no transactions are available yet, wait and poll the endpoint.
-		// Normally, we would listen for a webhook before calling
-		// /transactions/sync instead of polling, but the Quickstart doesn't
+		// Normally, we would listen for a webhook, but the Quickstart doesn't
 		// support webhooks. For a webhook example, see
 		// https://github.com/plaid/tutorial-resources or
 		// https://github.com/plaid/pattern

--- a/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
@@ -32,7 +32,7 @@ public class TransactionsResource {
   }
 
   @GET
-  public TransactionsResponse getTransactions() throws IOException {
+  public TransactionsResponse getTransactions() throws IOException, InterruptedException {
     // Set cursor to empty to receive all historical updates
     String cursor = null;
 
@@ -50,13 +50,24 @@ public class TransactionsResource {
       Response<TransactionsSyncResponse> response = plaidClient.transactionsSync(request).execute();
       TransactionsSyncResponse responseBody = response.body();
 
+      cursor = responseBody.getNextCursor();
+
+      // If no transactions are available yet, wait and poll the endpoint.
+      // Normally, we would listen for a webhook before calling
+      // /transactions/sync instead of polling, but the Quickstart doesn't
+      // support webhooks. For a webhook example, see
+      // https://github.com/plaid/tutorial-resources or
+      // https://github.com/plaid/pattern
+
+      if (cursor.equals("")) {
+          Thread.sleep(2000); 
+          continue; 
+      }
       // Add this page of results
       added.addAll(responseBody.getAdded());
       modified.addAll(responseBody.getModified());
       removed.addAll(responseBody.getRemoved());
       hasMore = responseBody.getHasMore();
-      // Update cursor to the next cursor
-      cursor = responseBody.getNextCursor();
     }
 
     // Return the 8 most recent transactions

--- a/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
@@ -53,8 +53,7 @@ public class TransactionsResource {
       cursor = responseBody.getNextCursor();
 
       // If no transactions are available yet, wait and poll the endpoint.
-      // Normally, we would listen for a webhook before calling
-      // /transactions/sync instead of polling, but the Quickstart doesn't
+      // Normally, we would listen for a webhook, but the Quickstart doesn't
       // support webhooks. For a webhook example, see
       // https://github.com/plaid/tutorial-resources or
       // https://github.com/plaid/pattern

--- a/node/index.js
+++ b/node/index.js
@@ -258,8 +258,7 @@ app.get('/api/transactions', function (request, response, next) {
         const data = response.data;
 
         // If no transactions are available yet, wait and poll the endpoint.
-        // Normally, we would listen for a webhook before calling
-        // /transactions/sync instead of polling, but the Quickstart doesn't
+        // Normally, we would listen for a webhook, but the Quickstart doesn't
         // support webhooks. For a webhook example, see
         // https://github.com/plaid/tutorial-resources or
         // https://github.com/plaid/pattern

--- a/node/index.js
+++ b/node/index.js
@@ -15,6 +15,8 @@ const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
 const PLAID_SECRET = process.env.PLAID_SECRET;
 const PLAID_ENV = process.env.PLAID_ENV || 'sandbox';
 
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
 // PLAID_PRODUCTS is a comma-separated list of products to use when initializing
 // Link. Note that this list must contain 'assets' in order for the app to be
 // able to create and retrieve asset reports.
@@ -254,13 +256,25 @@ app.get('/api/transactions', function (request, response, next) {
         };
         const response = await client.transactionsSync(request)
         const data = response.data;
+
+        // If no transactions are available yet, wait and poll the endpoint.
+        // Normally, we would listen for a webhook before calling
+        // /transactions/sync instead of polling, but the Quickstart doesn't
+        // support webhooks. For a webhook example, see
+        // https://github.com/plaid/tutorial-resources or
+        // https://github.com/plaid/pattern
+        cursor = data.next_cursor;
+        if (cursor === "") {
+          await sleep(2000);
+          continue; 
+      }
+  
         // Add this page of results
         added = added.concat(data.added);
         modified = modified.concat(data.modified);
         removed = removed.concat(data.removed);
         hasMore = data.has_more;
-        // Update cursor to the next cursor
-        cursor = data.next_cursor;
+        
         prettyPrintResponse(response);
       }
 

--- a/python/server.py
+++ b/python/server.py
@@ -298,12 +298,6 @@ def get_transactions():
                 cursor=cursor,
             )
             response = client.transactions_sync(request).to_dict()
-            # Add this page of results
-            added.extend(response['added'])
-            modified.extend(response['modified'])
-            removed.extend(response['removed'])
-            has_more = response['has_more']
-            # Update cursor to the next cursor
             cursor = response['next_cursor']
             # If no transactions are available yet, wait and poll the endpoint.
             # Normally, we would listen for a webhook before calling 
@@ -311,9 +305,15 @@ def get_transactions():
             # support webhooks. For a webhook example, see 
             # https://github.com/plaid/tutorial-resources or
             # https://github.com/plaid/pattern
-            if cursor is None:
+            if cursor == '':
                 time.sleep(2)
                 continue  
+            # If cursor is not an empty string, we got results, 
+            # so add this page of results
+            added.extend(response['added'])
+            modified.extend(response['modified'])
+            removed.extend(response['removed'])
+            has_more = response['has_more']
             pretty_print_response(response)
 
         # Return the 8 most recent transactions

--- a/python/server.py
+++ b/python/server.py
@@ -299,8 +299,7 @@ def get_transactions():
             response = client.transactions_sync(request).to_dict()
             cursor = response['next_cursor']
             # If no transactions are available yet, wait and poll the endpoint.
-            # Normally, we would listen for a webhook before calling 
-            # /transactions/sync instead of polling, but the Quickstart doesn't 
+            # Normally, we would listen for a webhook, but the Quickstart doesn't 
             # support webhooks. For a webhook example, see 
             # https://github.com/plaid/tutorial-resources or
             # https://github.com/plaid/pattern

--- a/python/server.py
+++ b/python/server.py
@@ -215,6 +215,7 @@ def create_link_token():
             client_name="Plaid Quickstart",
             country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
             language='en',
+            webhook='https://webhook.site/4cc0ff67-8cc8-4b71-ad9c-c2f9c9ac5a15',
             user=LinkTokenCreateRequestUser(
                 client_user_id=str(time.time())
             )
@@ -304,6 +305,15 @@ def get_transactions():
             has_more = response['has_more']
             # Update cursor to the next cursor
             cursor = response['next_cursor']
+            # If no transactions are available yet, wait and poll the endpoint.
+            # Normally, we would listen for a webhook before calling 
+            # /transactions/sync instead of polling, but the Quickstart doesn't 
+            # support webhooks. For a webhook example, see 
+            # https://github.com/plaid/tutorial-resources or
+            # https://github.com/plaid/pattern
+            if cursor is None:
+                time.sleep(2)
+                continue  
             pretty_print_response(response)
 
         # Return the 8 most recent transactions

--- a/python/server.py
+++ b/python/server.py
@@ -215,7 +215,6 @@ def create_link_token():
             client_name="Plaid Quickstart",
             country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
             language='en',
-            webhook='https://webhook.site/4cc0ff67-8cc8-4b71-ad9c-c2f9c9ac5a15',
             user=LinkTokenCreateRequestUser(
                 client_user_id=str(time.time())
             )

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -89,13 +89,24 @@ get '/api/transactions' do
         }
       )
       response = client.transactions_sync(request)
+      cursor = response.next_cursor
+
+      # If no transactions are available yet, wait and poll the endpoint.
+      # Normally, we would listen for a webhook before calling 
+      # /transactions/sync instead of polling, but the Quickstart doesn't 
+      # support webhooks. For a webhook example, see 
+      # https://github.com/plaid/tutorial-resources or
+      # https://github.com/plaid/pattern
+      if cursor == ""
+        sleep 2 
+        next 
+      end
+    
       # Add this page of results
       added += response.added
       modified += response.modified
       removed += response.removed
       has_more = response.has_more
-      # Update cursor to the next cursor
-      cursor = response.next_cursor
       pretty_print_response(response.to_hash)
     end
     # Return the 8 most recent transactions

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -92,8 +92,7 @@ get '/api/transactions' do
       cursor = response.next_cursor
 
       # If no transactions are available yet, wait and poll the endpoint.
-      # Normally, we would listen for a webhook before calling 
-      # /transactions/sync instead of polling, but the Quickstart doesn't 
+      # Normally, we would listen for a webhook but the Quickstart doesn't 
       # support webhooks. For a webhook example, see 
       # https://github.com/plaid/tutorial-resources or
       # https://github.com/plaid/pattern


### PR DESCRIPTION
Prior to the Quickstart being migrated to `/transactions/sync` instead of `/transactions/get`, we used to have a retry loop so that if you requested transactions before they're ready, we would sleep for a few seconds and try again. After the migration to `/transactions/sync`, that code was lost, and now the current behavior is that if you click on the transactions sync button too quickly after Link completes, no transactions load when you click the button and it makes the Quickstart look broken. (This is most likely to happen if you are using Production rather than Sandbox, since Sandbox is artificially fast.) This PR fixes that behavior and restores the previous retry polling.