### PR TITLE
Update docs link in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ PLAID_ENV=sandbox
 
 # PLAID_PRODUCTS is a comma-separated list of products to use when
 # initializing Link, e.g. PLAID_PRODUCTS=auth,transactions.
-# see https://plaid.com/docs/api/tokens/#link-token-create-request-products for a complete list.
+# see https://plaid.com/docs/api/link/#link-token-create-request-products for a complete list.
 # Only institutions that support ALL listed products will work.
 # If you don't see the institution you want in Link, or get a "Connectivity not supported" error, 
 # Remove any products you aren't using.
@@ -30,7 +30,7 @@ PLAID_PRODUCTS=auth,transactions
 # initializing Link, e.g. PLAID_COUNTRY_CODES=US,CA.
 # Institutions from all listed countries will be shown. If Link is launched with multiple country codes,
 # only products that you are enabled for in all countries will be used by Link.
-# See https://plaid.com/docs/api/tokens/#link-token-create-request-country-codes for a complete list
+# See https://plaid.com/docs/api/link/#link-token-create-request-country-codes for a complete list
 PLAID_COUNTRY_CODES=US,CA
 
 # PLAID_REDIRECT_URI is optional for this Quickstart application.


### PR DESCRIPTION
The docs link in .env.example are dead and result in 404s. Update the links to the correct URLs.

![image](https://github.com/user-attachments/assets/c9ec337d-c3de-4210-a404-2ed5cae06d85)

![image](https://github.com/user-attachments/assets/b3ce5e14-1b29-4300-9cd8-9e67a598c9a7)

