### PR TITLE
fix sinatra error

### DIFF
--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -10,9 +10,10 @@ require 'sinatra'
 
 set :port, ENV['APP_PORT'] || 8000
 
-# disable CSRF warning on localhost due to usage of local /api proxy in react app.
+# disable CSRF warning and Rack protection on localhost due to usage of local /api proxy in react app.
 # delete this for a production application.
 set :protection, :except => [:json_csrf]
+set :host_authorization, { permitted_hosts: [] }
 
 configuration = Plaid::Configuration.new
 configuration.server_index = Plaid::Configuration::Environment[ENV['PLAID_ENV'] || 'sandbox']


### PR DESCRIPTION
A user found an issue in which the ruby quickstart fails to start due to a breaking change introduced in a middle digit version upgrade of Sinatra :-( 

```
"attack prevented by Rack::Protection::HostAuthorization


172.18.0.2 - - [05/May/2025:17:20:40 +0000] "POST /api/create_link_token HTTP/1.1" 403 - 0.0003"
```

Adding this change fixes the issue.

It is unsafe for production deployments and is called out as such.