### PR TITLE
Fix error reporting and handling across all quickstart backends

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,11 +80,22 @@ const App = () => {
       const response = await fetch(path, {
         method: "POST",
       });
+      const data = await response.json();
       if (!response.ok) {
-        dispatch({ type: "SET_STATE", state: { linkToken: null } });
+        dispatch({
+          type: "SET_STATE",
+          state: {
+            linkToken: null,
+            linkTokenError: data.error || {
+              error_code: data.error_code || "UNKNOWN",
+              error_type: data.error_type || "API_ERROR",
+              error_message:
+                data.error_message || `Request failed with status ${response.status}`,
+            },
+          },
+        });
         return;
       }
-      const data = await response.json();
       if (data) {
         if (data.error != null) {
           dispatch({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,22 +80,30 @@ const App = () => {
       const response = await fetch(path, {
         method: "POST",
       });
-      const data = await response.json();
       if (!response.ok) {
+        let errorDetail;
+        try {
+          const data = await response.json();
+          errorDetail = data.error || {
+            error_code: data.error_code || "UNKNOWN",
+            error_type: data.error_type || "API_ERROR",
+            error_message:
+              data.error_message || `Request failed with status ${response.status}`,
+          };
+        } catch {
+          errorDetail = {
+            error_code: "UNKNOWN",
+            error_type: "API_ERROR",
+            error_message: `Request failed with status ${response.status}`,
+          };
+        }
         dispatch({
           type: "SET_STATE",
-          state: {
-            linkToken: null,
-            linkTokenError: data.error || {
-              error_code: data.error_code || "UNKNOWN",
-              error_type: data.error_type || "API_ERROR",
-              error_message:
-                data.error_message || `Request failed with status ${response.status}`,
-            },
-          },
+          state: { linkToken: null, linkTokenError: errorDetail },
         });
         return;
       }
+      const data = await response.json();
       if (data) {
         if (data.error != null) {
           dispatch({

--- a/frontend/src/Components/Error/index.tsx
+++ b/frontend/src/Components/Error/index.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import Button from "plaid-threads/Button";
 import Note from "plaid-threads/Note";
 
+import InlineLink from "plaid-threads/InlineLink";
+
 import { ErrorDataItem } from "../../dataUtilities";
 
 import styles from "./index.module.scss";
@@ -68,6 +70,39 @@ const Error = (props: Props) => {
             </span>
           </div>
         </div>
+        {props.error.error_code === "INVALID_LINK_CUSTOMIZATION" && (
+          <div className={styles.errorItem}>
+            <span className={styles.errorMessage}>
+              <strong>Tip:</strong> In the{" "}
+              <InlineLink
+                href="https://dashboard.plaid.com/link/data-transparency-v5"
+                target="_blank"
+              >
+                dashboard under Link &gt; Link Customization Data Transparency
+                Messaging
+              </InlineLink>
+              , ensure at least one use case is selected. After selecting a use
+              case, make sure to click <strong>Publish Changes</strong>.
+            </span>
+          </div>
+        )}
+        {props.error.error_code === "INSTITUTION_REGISTRATION_REQUIRED" && (
+          <div className={styles.errorItem}>
+            <span className={styles.errorMessage}>
+              Certain OAuth institutions, including Bank of America, Chase,
+              Capital One, and American Express, may take up to 24 hours to
+              become available after obtaining Production access. PNC and Charles
+              Schwab require a{" "}
+              <InlineLink
+                href="https://dashboard.plaid.com/activity/status/oauth-institutions"
+                target="_blank"
+              >
+                special registration process
+              </InlineLink>{" "}
+              to access Production data.
+            </span>
+          </div>
+        )}
         <Button
           small
           wide

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -19,6 +19,7 @@ const Header = () => {
     isItemAccess,
     backend,
     linkTokenError,
+    linkExitError,
     isPaymentInitiation,
   } = useContext(Context);
 
@@ -89,6 +90,23 @@ const Header = () => {
             <div className={styles.linkButton}>
               <Link />
             </div>
+          )}
+          {linkExitError != null && (
+            <Callout warning>
+              <div>
+                Link exited with an error.
+              </div>
+              <div>
+                Error Code: <code>{linkExitError.error_code}</code>
+              </div>
+              <div>
+                Error Type: <code>{linkExitError.error_type}</code>
+              </div>
+              <div>Error Message: {linkExitError.error_message}</div>
+              {linkExitError.display_message && (
+                <div>Details: {linkExitError.display_message}</div>
+              )}
+            </Callout>
           )}
         </>
       ) : (

--- a/frontend/src/Components/Headers/index.tsx
+++ b/frontend/src/Components/Headers/index.tsx
@@ -79,6 +79,20 @@ const Header = () => {
                 Error Type: <code>{linkTokenError.error_type}</code>{" "}
               </div>
               <div>Error Message: {linkTokenError.error_message}</div>
+              {linkTokenError.error_code === "INVALID_LINK_CUSTOMIZATION" && (
+                <div>
+                  <strong>Tip:</strong> In the{" "}
+                  <InlineLink
+                    href="https://dashboard.plaid.com/link/data-transparency-v5"
+                    target="_blank"
+                  >
+                    dashboard under Link &gt; Link Customization Data
+                    Transparency Messaging
+                  </InlineLink>
+                  , ensure at least one use case is selected. After selecting a
+                  use case, make sure to click <strong>Publish Changes</strong>.
+                </div>
+              )}
             </Callout>
           ) : linkToken === "" ? (
             <div className={styles.linkButton}>
@@ -106,6 +120,45 @@ const Header = () => {
               {linkExitError.display_message && (
                 <div>Details: {linkExitError.display_message}</div>
               )}
+              {linkExitError.error_code === "INVALID_LINK_CUSTOMIZATION" && (
+                <div>
+                  <strong>Tip:</strong> In the{" "}
+                  <InlineLink
+                    href="https://dashboard.plaid.com/link/data-transparency-v5"
+                    target="_blank"
+                  >
+                    dashboard under Link &gt; Link Customization Data
+                    Transparency Messaging
+                  </InlineLink>
+                  , ensure at least one use case is selected. After selecting a
+                  use case, make sure to click <strong>Publish Changes</strong>.
+                </div>
+              )}
+              {linkExitError.error_code ===
+                "INSTITUTION_REGISTRATION_REQUIRED" &&
+                (["PNC", "Charles Schwab"].some((name) =>
+                  linkExitError.institution_name
+                    ?.toLowerCase()
+                    .includes(name.toLowerCase())
+                ) ? (
+                  <div>
+                    {linkExitError.institution_name} requires a special
+                    registration process to access Production data. See{" "}
+                    <InlineLink
+                      href="https://dashboard.plaid.com/activity/status/oauth-institutions"
+                      target="_blank"
+                    >
+                      OAuth institution status
+                    </InlineLink>{" "}
+                    for details.
+                  </div>
+                ) : (
+                  <div>
+                    Certain OAuth institutions, including Bank of America,
+                    Chase, Capital One, and American Express, may take up to 24
+                    hours to become available after obtaining Production access.
+                  </div>
+                ))}
             </Callout>
           )}
         </>

--- a/frontend/src/Components/Link/index.tsx
+++ b/frontend/src/Components/Link/index.tsx
@@ -8,6 +8,25 @@ const Link = () => {
   const { linkToken, isPaymentInitiation, isCraProductsExclusively, dispatch } =
     useContext(Context);
 
+  const onExit = React.useCallback(
+    (error: any) => {
+      if (error != null) {
+        dispatch({
+          type: "SET_STATE",
+          state: {
+            linkExitError: {
+              error_type: error.error_type || "",
+              error_code: error.error_code || "",
+              error_message: error.error_message || "",
+              display_message: error.display_message || "",
+            },
+          },
+        });
+      }
+    },
+    [dispatch]
+  );
+
   const onSuccess = React.useCallback(
     (public_token: string) => {
       // If the access_token is needed, send public_token to server
@@ -61,6 +80,7 @@ const Link = () => {
   const config: Parameters<typeof usePlaidLink>[0] = {
     token: linkToken!,
     onSuccess,
+    onExit,
   };
 
   if (window.location.href.includes("?oauth_state_id=")) {

--- a/frontend/src/Components/Link/index.tsx
+++ b/frontend/src/Components/Link/index.tsx
@@ -9,18 +9,23 @@ const Link = () => {
     useContext(Context);
 
   const onExit = React.useCallback(
-    (error: any) => {
+    (error: any, metadata: any) => {
       if (error != null) {
+        const linkExitError = {
+          error_type: error.error_type || "",
+          error_code: error.error_code || "",
+          error_message: error.error_message || "",
+          display_message: error.display_message || "",
+          institution_name: metadata?.institution?.name || "",
+        };
         dispatch({
           type: "SET_STATE",
-          state: {
-            linkExitError: {
-              error_type: error.error_type || "",
-              error_code: error.error_code || "",
-              error_message: error.error_message || "",
-              display_message: error.display_message || "",
-            },
-          },
+          state: { linkExitError },
+        });
+        fetch("/api/link_exit_error", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(linkExitError),
         });
       }
     },

--- a/frontend/src/Context/index.tsx
+++ b/frontend/src/Context/index.tsx
@@ -19,6 +19,12 @@ interface QuickstartState {
     error_code: string;
     error_type: string;
   };
+  linkExitError: {
+    error_message: string;
+    error_code: string;
+    error_type: string;
+    display_message: string;
+  } | null;
 }
 
 const initialState: QuickstartState = {
@@ -40,6 +46,7 @@ const initialState: QuickstartState = {
     error_code: "",
     error_message: "",
   },
+  linkExitError: null,
 };
 
 type QuickstartAction = {

--- a/frontend/src/Context/index.tsx
+++ b/frontend/src/Context/index.tsx
@@ -24,6 +24,7 @@ interface QuickstartState {
     error_code: string;
     error_type: string;
     display_message: string;
+    institution_name: string;
   } | null;
 }
 

--- a/go/server.go
+++ b/go/server.go
@@ -1057,8 +1057,10 @@ func pollWithRetries[T any](requestCallback func() (T, error), ms int, retriesLe
 	}
 	response, err := requestCallback()
 	if err != nil {
-		plaidErr, err := plaid.ToPlaidError(err)
-		if plaidErr.ErrorCode != "PRODUCT_NOT_READY" {
+		plaidErr, parseErr := plaid.ToPlaidError(err)
+		isProductNotReady := parseErr == nil && plaidErr.ErrorCode == "PRODUCT_NOT_READY"
+		isServerError := parseErr == nil && plaidErr.HasStatus() && plaidErr.GetStatus() >= 500
+		if !isProductNotReady && !isServerError {
 			return zero, err
 		}
 		time.Sleep(time.Duration(ms) * time.Millisecond)

--- a/go/server.go
+++ b/go/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -98,6 +99,7 @@ func main() {
 	// 3. Re-initialize with the link token (from step 1) and the full received redirect URI
 	// from step 2.
 
+	r.POST("/api/link_exit_error", linkExitError)
 	r.POST("/api/set_access_token", getAccessToken)
 	r.POST("/api/create_link_token_for_payment", createLinkTokenForPayment)
 	r.GET("/api/auth", auth)
@@ -144,13 +146,31 @@ var paymentID string
 var authorizationID string
 var accountID string
 
+func linkExitError(c *gin.Context) {
+	var body map[string]interface{}
+	if err := c.BindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+		return
+	}
+	jsonBytes, _ := json.MarshalIndent(body, "", "  ")
+	fmt.Println("[Link Exit Error (frontend)]")
+	fmt.Println(string(jsonBytes))
+	c.JSON(http.StatusOK, gin.H{"status": "logged"})
+}
+
 func renderError(c *gin.Context, originalErr error) {
 	if plaidError, err := plaid.ToPlaidError(originalErr); err == nil {
-		// Return 200 and allow the front end to render the error.
-		c.JSON(http.StatusOK, gin.H{"error": plaidError})
+		errorJSON, _ := json.MarshalIndent(plaidError, "", "  ")
+		fmt.Println(string(errorJSON))
+		statusCode := int(plaidError.GetStatus())
+		if statusCode == 0 {
+			statusCode = http.StatusInternalServerError
+		}
+		c.JSON(statusCode, gin.H{"error": plaidError})
 		return
 	}
 
+	fmt.Println(originalErr.Error())
 	c.JSON(http.StatusInternalServerError, gin.H{"error": originalErr.Error()})
 }
 

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiException.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiException.java
@@ -1,0 +1,16 @@
+package com.plaid.quickstart;
+
+import java.util.Map;
+
+public class PlaidApiException extends RuntimeException {
+    private final Map<String, Object> errorResponse;
+
+    public PlaidApiException(Map<String, Object> errorResponse) {
+        super(errorResponse.toString());
+        this.errorResponse = errorResponse;
+    }
+
+    public Map<String, Object> getErrorResponse() {
+        return errorResponse;
+    }
+}

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiException.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiException.java
@@ -4,13 +4,19 @@ import java.util.Map;
 
 public class PlaidApiException extends RuntimeException {
     private final Map<String, Object> errorResponse;
+    private final int statusCode;
 
-    public PlaidApiException(Map<String, Object> errorResponse) {
+    public PlaidApiException(Map<String, Object> errorResponse, int statusCode) {
         super(errorResponse.toString());
         this.errorResponse = errorResponse;
+        this.statusCode = statusCode;
     }
 
     public Map<String, Object> getErrorResponse() {
         return errorResponse;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 }

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiExceptionMapper.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiExceptionMapper.java
@@ -7,7 +7,10 @@ import javax.ws.rs.ext.ExceptionMapper;
 public class PlaidApiExceptionMapper implements ExceptionMapper<PlaidApiException> {
     @Override
     public Response toResponse(PlaidApiException exception) {
-        return Response.ok(exception.getErrorResponse())
+        System.out.println(exception.getErrorResponse());
+        int statusCode = exception.getStatusCode();
+        return Response.status(statusCode)
+            .entity(exception.getErrorResponse())
             .type(MediaType.APPLICATION_JSON)
             .build();
     }

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiExceptionMapper.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiExceptionMapper.java
@@ -1,0 +1,14 @@
+package com.plaid.quickstart;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class PlaidApiExceptionMapper implements ExceptionMapper<PlaidApiException> {
+    @Override
+    public Response toResponse(PlaidApiException exception) {
+        return Response.ok(exception.getErrorResponse())
+            .type(MediaType.APPLICATION_JSON)
+            .build();
+    }
+}

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiHelper.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiHelper.java
@@ -23,6 +23,7 @@ public class PlaidApiHelper {
                 error.put("error_code", body.getOrDefault("error_code", "UNKNOWN"));
                 error.put("error_type", body.getOrDefault("error_type", "API_ERROR"));
                 error.put("error_message", body.getOrDefault("error_message", errorBody));
+                error.put("display_message", body.get("display_message"));
             } catch (Exception e) {
                 error.put("error_code", "UNKNOWN");
                 error.put("error_type", "API_ERROR");
@@ -30,7 +31,7 @@ public class PlaidApiHelper {
             }
             Map<String, Object> result = new HashMap<>();
             result.put("error", error);
-            throw new PlaidApiException(result);
+            throw new PlaidApiException(result, response.code());
         }
         return response.body();
     }

--- a/java/src/main/java/com/plaid/quickstart/PlaidApiHelper.java
+++ b/java/src/main/java/com/plaid/quickstart/PlaidApiHelper.java
@@ -1,0 +1,37 @@
+package com.plaid.quickstart;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PlaidApiHelper {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
+    public static <T> T callPlaid(Call<T> call) throws IOException {
+        Response<T> response = call.execute();
+        if (!response.isSuccessful()) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("status_code", response.code());
+            try {
+                String errorBody = response.errorBody().string();
+                Map<String, Object> body = mapper.readValue(errorBody, Map.class);
+                error.put("error_code", body.getOrDefault("error_code", "UNKNOWN"));
+                error.put("error_type", body.getOrDefault("error_type", "API_ERROR"));
+                error.put("error_message", body.getOrDefault("error_message", errorBody));
+            } catch (Exception e) {
+                error.put("error_code", "UNKNOWN");
+                error.put("error_type", "API_ERROR");
+                error.put("error_message", "Unknown error (HTTP " + response.code() + ")");
+            }
+            Map<String, Object> result = new HashMap<>();
+            result.put("error", error);
+            throw new PlaidApiException(result);
+        }
+        return response.body();
+    }
+}

--- a/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
+++ b/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
@@ -14,6 +14,7 @@ import com.plaid.quickstart.resources.IdentityResource;
 import com.plaid.quickstart.resources.InfoResource;
 import com.plaid.quickstart.resources.InvestmentTransactionsResource;
 import com.plaid.quickstart.resources.ItemResource;
+import com.plaid.quickstart.resources.LinkExitErrorResource;
 import com.plaid.quickstart.resources.LinkTokenResource;
 import com.plaid.quickstart.resources.LinkTokenWithPaymentResource;
 import com.plaid.quickstart.resources.PaymentInitiationResource;
@@ -118,6 +119,7 @@ public class QuickstartApplication extends Application<QuickstartConfiguration> 
     environment.jersey().register(new InfoResource(plaidProducts));
     environment.jersey().register(new InvestmentTransactionsResource(plaidClient));
     environment.jersey().register(new ItemResource(plaidClient));
+    environment.jersey().register(new LinkExitErrorResource());
     environment.jersey().register(new LinkTokenResource(plaidClient, plaidProducts, countryCodes, redirectUri));
     environment.jersey().register(new LinkTokenWithPaymentResource(plaidClient, plaidProducts, countryCodes, redirectUri));
     environment.jersey().register(new PaymentInitiationResource(plaidClient));

--- a/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
+++ b/java/src/main/java/com/plaid/quickstart/QuickstartApplication.java
@@ -107,6 +107,7 @@ public class QuickstartApplication extends Application<QuickstartConfiguration> 
 
     plaidClient = apiClient.createService(PlaidApi.class);
 
+    environment.jersey().register(new PlaidApiExceptionMapper());
     environment.jersey().register(new AccessTokenResource(plaidClient, plaidProducts));
     environment.jersey().register(new AccountsResource(plaidClient));
     environment.jersey().register(new AssetsResource(plaidClient));

--- a/java/src/main/java/com/plaid/quickstart/resources/AccessTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AccessTokenResource.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.ItemPublicTokenExchangeRequest;
 import com.plaid.client.model.ItemPublicTokenExchangeResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 import com.plaid.client.model.Products;
 
@@ -18,8 +19,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import retrofit2.Response;
 
 @Path("/set_access_token")
 @Produces(MediaType.APPLICATION_JSON)
@@ -39,17 +38,15 @@ public class AccessTokenResource {
       ItemPublicTokenExchangeRequest request = new ItemPublicTokenExchangeRequest()
       .publicToken(publicToken);
 
-    Response<ItemPublicTokenExchangeResponse> response = plaidClient
-      .itemPublicTokenExchange(request)
-      .execute();
+    ItemPublicTokenExchangeResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.itemPublicTokenExchange(request));
 
     // Ideally, we would store this somewhere more persistent
-    QuickstartApplication.
-      accessToken = response.body().getAccessToken();
-    QuickstartApplication.itemId = response.body().getItemId();
+    QuickstartApplication.accessToken = responseBody.getAccessToken();
+    QuickstartApplication.itemId = responseBody.getItemId();
     LOG.info("public token: " + publicToken);
     LOG.info("access token: " + QuickstartApplication.accessToken);
-    LOG.info("item ID: " + response.body().getItemId());
+    LOG.info("item ID: " + responseBody.getItemId());
     return new InfoResource.InfoResponse(Arrays.asList(), QuickstartApplication.accessToken,
       QuickstartApplication.itemId);
   }

--- a/java/src/main/java/com/plaid/quickstart/resources/AccountsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AccountsResource.java
@@ -5,14 +5,13 @@ import java.io.IOException;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.AccountsGetRequest;
 import com.plaid.client.model.AccountsGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/accounts")
 @Produces(MediaType.APPLICATION_JSON)
@@ -28,9 +27,6 @@ public class AccountsResource {
     AccountsGetRequest request = new AccountsGetRequest()
     .accessToken(QuickstartApplication.accessToken);
 
-    Response<AccountsGetResponse> response = plaidClient
-      .accountsGet(request)
-      .execute();
-    return response.body();
+    return PlaidApiHelper.callPlaid(plaidClient.accountsGet(request));
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
@@ -9,13 +9,11 @@ import com.plaid.client.model.AssetReportCreateResponse;
 import com.plaid.client.model.AssetReportGetRequest;
 import com.plaid.client.model.AssetReportGetResponse;
 import com.plaid.client.model.AssetReportPDFGetRequest;
+import com.plaid.quickstart.PlaidApiException;
 import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
-import com.plaid.client.model.PlaidError;
-import com.plaid.client.model.PlaidErrorType;
 import okhttp3.ResponseBody;
 
-import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,10 +22,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
-import com.google.gson.Gson;
-import com.google.common.base.Throwables;
 
 @Path("/assets")
 @Produces(MediaType.APPLICATION_JSON)
@@ -53,22 +47,30 @@ public class AssetsResource {
     String assetReportToken = assetReportCreateResponseBody.getAssetReportToken();
     AssetReportGetRequest assetReportGetRequest = new AssetReportGetRequest()
       .assetReportToken(assetReportToken);
-    Response<AssetReportGetResponse> assetReportGetResponse = null;
-    
-    //In a real integration, we would wait for a webhook rather than polling like this
-    for (int i = 0; i < 5; i++){
-      assetReportGetResponse = plaidClient.assetReportGet(assetReportGetRequest).execute();
-      if (assetReportGetResponse.isSuccessful()){
+
+    // In a real integration, we would wait for a webhook rather than polling like this
+    AssetReportGetResponse assetReportGetResponseBody = null;
+    for (int i = 0; i <= 20; i++) {
+      try {
+        assetReportGetResponseBody = PlaidApiHelper.callPlaid(
+          plaidClient.assetReportGet(assetReportGetRequest));
         break;
-      } else {
+      } catch (PlaidApiException e) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = (Map<String, Object>) e.getErrorResponse().get("error");
+        boolean isProductNotReady = error != null && "PRODUCT_NOT_READY".equals(error.get("error_code"));
+        boolean isServerError = error != null && error.get("status_code") instanceof Integer && (Integer) error.get("status_code") >= 500;
+        if (!isProductNotReady && !isServerError) {
+          throw e;
+        }
+        if (i == 20) {
+          throw e;
+        }
         try {
-          Gson gson = new Gson();
-          PlaidError error = gson.fromJson(assetReportGetResponse.errorBody().string(), PlaidError.class);
-          error.getErrorType().equals(PlaidErrorType.ASSET_REPORT_ERROR);
-          error.getErrorCode().equals("PRODUCT_NOT_READY");
-          Thread.sleep(5000);
-        } catch (Exception e) {
-          throw Throwables.propagate(e);
+          Thread.sleep(1000);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Interrupted while polling for asset report", ie);
         }
       }
     }
@@ -81,7 +83,7 @@ public class AssetsResource {
 
     String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponseBody.bytes());
     Map<String, Object> responseMap = new HashMap<>();
-    responseMap.put("json", assetReportGetResponse.body().getReport());
+    responseMap.put("json", assetReportGetResponseBody.getReport());
     responseMap.put("pdf", pdf);
     return responseMap;
 

--- a/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AssetsResource.java
@@ -9,6 +9,7 @@ import com.plaid.client.model.AssetReportCreateResponse;
 import com.plaid.client.model.AssetReportGetRequest;
 import com.plaid.client.model.AssetReportGetResponse;
 import com.plaid.client.model.AssetReportPDFGetRequest;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 import com.plaid.client.model.PlaidError;
 import com.plaid.client.model.PlaidErrorType;
@@ -46,11 +47,10 @@ public class AssetsResource {
       .accessTokens(accessTokens)
       .daysRequested(10);
 
-    Response<AssetReportCreateResponse> assetReportCreateResponse = plaidClient
-      .assetReportCreate(assetReportCreateRequest)
-      .execute();
+    AssetReportCreateResponse assetReportCreateResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.assetReportCreate(assetReportCreateRequest));
 
-    String assetReportToken = assetReportCreateResponse.body().getAssetReportToken();
+    String assetReportToken = assetReportCreateResponseBody.getAssetReportToken();
     AssetReportGetRequest assetReportGetRequest = new AssetReportGetRequest()
       .assetReportToken(assetReportToken);
     Response<AssetReportGetResponse> assetReportGetResponse = null;
@@ -76,11 +76,10 @@ public class AssetsResource {
     AssetReportPDFGetRequest assetReportPDFGetRequest = new AssetReportPDFGetRequest()
       .assetReportToken(assetReportToken);
 
-    Response<ResponseBody> assetReportPDFGetResponse = plaidClient
-      .assetReportPdfGet(assetReportPDFGetRequest)
-      .execute();
+    ResponseBody assetReportPDFGetResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.assetReportPdfGet(assetReportPDFGetRequest));
 
-    String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponse.body().bytes());
+    String pdf = Base64.getEncoder().encodeToString(assetReportPDFGetResponseBody.bytes());
     Map<String, Object> responseMap = new HashMap<>();
     responseMap.put("json", assetReportGetResponse.body().getReport());
     responseMap.put("pdf", pdf);

--- a/java/src/main/java/com/plaid/quickstart/resources/AuthResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/AuthResource.java
@@ -5,14 +5,13 @@ import java.io.IOException;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.AuthGetRequest;
 import com.plaid.client.model.AuthGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/auth")
 @Produces(MediaType.APPLICATION_JSON)
@@ -28,10 +27,6 @@ public class AuthResource {
 
     AuthGetRequest request = new AuthGetRequest()
     .accessToken(QuickstartApplication.accessToken);
-    Response<AuthGetResponse> response = plaidClient
-      .authGet(request)
-      .execute();
-
-    return response.body();
+    return PlaidApiHelper.callPlaid(plaidClient.authGet(request));
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/BalanceResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/BalanceResource.java
@@ -7,14 +7,13 @@ import java.util.Map;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.AccountsBalanceGetRequest;
 import com.plaid.client.model.AccountsGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/balance")
 @Produces(MediaType.APPLICATION_JSON)
@@ -30,12 +29,11 @@ public class BalanceResource {
     AccountsBalanceGetRequest balanceRequest = new AccountsBalanceGetRequest()
       .accessToken(QuickstartApplication.accessToken);
 
-    Response<AccountsGetResponse> balanceResponse = plaidClient
-      .accountsBalanceGet(balanceRequest)
-      .execute();
+    AccountsGetResponse balanceResponse = PlaidApiHelper.callPlaid(
+      plaidClient.accountsBalanceGet(balanceRequest));
 
     Map<String, Object> response = new HashMap<>();
-    response.put("accounts", balanceResponse.body().getAccounts());
+    response.put("accounts", balanceResponse.getAccounts());
 
     return response;
   }

--- a/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
@@ -139,7 +139,9 @@ public class CraResource {
         return PlaidApiHelper.callPlaid(call);
       } catch (PlaidApiException e) {
         Map<String, Object> error = (Map<String, Object>) e.getErrorResponse().get("error");
-        if (error == null || !"PRODUCT_NOT_READY".equals(error.get("error_code"))) {
+        boolean isProductNotReady = error != null && "PRODUCT_NOT_READY".equals(error.get("error_code"));
+        boolean isServerError = error != null && error.get("status_code") instanceof Integer && (Integer) error.get("status_code") >= 500;
+        if (!isProductNotReady && !isServerError) {
           throw e;
         }
         if (i == 20) {

--- a/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
@@ -19,6 +19,8 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;
 
+import java.util.Map;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -136,11 +138,15 @@ public class CraResource {
       try {
         return PlaidApiHelper.callPlaid(call);
       } catch (PlaidApiException e) {
+        Map<String, Object> error = (Map<String, Object>) e.getErrorResponse().get("error");
+        if (error == null || !"PRODUCT_NOT_READY".equals(error.get("error_code"))) {
+          throw e;
+        }
         if (i == 20) {
           throw e;
         }
         try {
-          Thread.sleep(5000);
+          Thread.sleep(1000);
         } catch (InterruptedException ie) {
           throw Throwables.propagate(ie);
         }

--- a/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
@@ -10,6 +10,8 @@ import com.plaid.client.model.CraCheckReportPartnerInsightsGetRequest;
 import com.plaid.client.model.CraCheckReportPartnerInsightsGetResponse;
 import com.plaid.client.model.CraPDFAddOns;
 import com.plaid.client.request.PlaidApi;
+import com.plaid.quickstart.PlaidApiException;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import com.google.common.base.Throwables;
@@ -49,8 +51,7 @@ public class CraResource {
       request.setUserId(QuickstartApplication.userId);
     }
     CraCheckReportBaseReportGetResponse baseReportResponse = pollWithRetries(
-      plaidClient.craCheckReportBaseReportGet(request)
-    ).body();
+      plaidClient.craCheckReportBaseReportGet(request));
 
     CraCheckReportPDFGetRequest pdfRequest = new CraCheckReportPDFGetRequest();
     // Use user_token if available, otherwise use user_id
@@ -59,9 +60,10 @@ public class CraResource {
     } else if (QuickstartApplication.userId != null) {
       pdfRequest.setUserId(QuickstartApplication.userId);
     }
-    Response<ResponseBody> pdfResponse = plaidClient.craCheckReportPdfGet(pdfRequest).execute();
+    ResponseBody pdfResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.craCheckReportPdfGet(pdfRequest));
 
-    String pdfBase64 = Base64.getEncoder().encodeToString(pdfResponse.body().bytes());
+    String pdfBase64 = Base64.getEncoder().encodeToString(pdfResponseBody.bytes());
 
     Map<String, Object> responseMap = new HashMap<>();
     responseMap.put("report", baseReportResponse.getReport());
@@ -84,9 +86,8 @@ public class CraResource {
     } else if (QuickstartApplication.userId != null) {
       request.setUserId(QuickstartApplication.userId);
     }
-    CraCheckReportIncomeInsightsGetResponse baseReportResponse = pollWithRetries(
-      plaidClient.craCheckReportIncomeInsightsGet(request)
-    ).body();
+    CraCheckReportIncomeInsightsGetResponse incomeInsightsResponse = pollWithRetries(
+      plaidClient.craCheckReportIncomeInsightsGet(request));
 
     CraCheckReportPDFGetRequest pdfRequest = new CraCheckReportPDFGetRequest();
     // Use user_token if available, otherwise use user_id
@@ -96,12 +97,13 @@ public class CraResource {
       pdfRequest.setUserId(QuickstartApplication.userId);
     }
     pdfRequest.addAddOnsItem(CraPDFAddOns.INCOME_INSIGHTS);
-    Response<ResponseBody> pdfResponse = plaidClient.craCheckReportPdfGet(pdfRequest).execute();
+    ResponseBody pdfResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.craCheckReportPdfGet(pdfRequest));
 
-    String pdfBase64 = Base64.getEncoder().encodeToString(pdfResponse.body().bytes());
+    String pdfBase64 = Base64.getEncoder().encodeToString(pdfResponseBody.bytes());
 
     Map<String, Object> responseMap = new HashMap<>();
-    responseMap.put("report", baseReportResponse.getReport());
+    responseMap.put("report", incomeInsightsResponse.getReport());
     responseMap.put("pdf", pdfBase64);
     return responseMap;
   }
@@ -118,7 +120,7 @@ public class CraResource {
     } else if (QuickstartApplication.userId != null) {
       request.setUserId(QuickstartApplication.userId);
     }
-    return pollWithRetries(plaidClient.craCheckReportPartnerInsightsGet(request)).body();
+    return pollWithRetries(plaidClient.craCheckReportPartnerInsightsGet(request));
   }
 
   // Since this quickstart does not support webhooks, this function can be used to
@@ -127,22 +129,22 @@ public class CraResource {
   // For a webhook example, see
   // https://github.com/plaid/tutorial-resources or
   // https://github.com/plaid/pattern
-  private <T> Response<T> pollWithRetries(Call<T> requestCallback) throws IOException {
+  private <T> T pollWithRetries(Call<T> requestCallback) throws IOException {
     for (int i = 0; i <= 20; i++) {
       // Clone the call for each retry since Retrofit calls can only be executed once
       Call<T> call = i == 0 ? requestCallback : requestCallback.clone();
-      Response<T> response = call.execute();
-
-      if (response.isSuccessful()) {
-        return response;
-      } else {
+      try {
+        return PlaidApiHelper.callPlaid(call);
+      } catch (PlaidApiException e) {
+        if (i == 20) {
+          throw e;
+        }
         try {
           Thread.sleep(5000);
-        } catch (Exception e) {
-          throw Throwables.propagate(e);
+        } catch (InterruptedException ie) {
+          throw Throwables.propagate(ie);
         }
       }
-
     }
     throw Throwables.propagate(new Exception("Ran out of retries while polling"));
   }

--- a/java/src/main/java/com/plaid/quickstart/resources/HoldingsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/HoldingsResource.java
@@ -7,14 +7,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.InvestmentsHoldingsGetRequest;
 import com.plaid.client.model.InvestmentsHoldingsGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/holdings")
 @Produces(MediaType.APPLICATION_JSON)
@@ -31,11 +30,10 @@ public class HoldingsResource {
     InvestmentsHoldingsGetRequest request = new InvestmentsHoldingsGetRequest()
     .accessToken(QuickstartApplication.accessToken);
 
-    Response<InvestmentsHoldingsGetResponse> response = plaidClient
-      .investmentsHoldingsGet(request)
-      .execute();
+    InvestmentsHoldingsGetResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.investmentsHoldingsGet(request));
 
-    return new HoldingsResponse(response.body());
+    return new HoldingsResponse(responseBody);
   }
 
   private static class HoldingsResponse {

--- a/java/src/main/java/com/plaid/quickstart/resources/IdentityResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/IdentityResource.java
@@ -7,6 +7,7 @@ import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.AccountIdentity;
 import com.plaid.client.model.IdentityGetRequest;
 import com.plaid.client.model.IdentityGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import java.util.List;
@@ -14,8 +15,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/identity")
 @Produces(MediaType.APPLICATION_JSON)
@@ -30,10 +29,9 @@ public class IdentityResource {
   public IdentityResponse getAccounts() throws IOException {
     IdentityGetRequest request = new IdentityGetRequest()
       .accessToken(QuickstartApplication.accessToken);
-    Response<IdentityGetResponse> response = plaidClient 
-    .identityGet(request)
-    .execute();
-    return new IdentityResponse(response.body());
+    IdentityGetResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.identityGet(request));
+    return new IdentityResponse(responseBody);
   }
 
   private static class IdentityResponse {

--- a/java/src/main/java/com/plaid/quickstart/resources/InvestmentTransactionsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/InvestmentTransactionsResource.java
@@ -7,6 +7,7 @@ import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.InvestmentsTransactionsGetRequest;
 import com.plaid.client.model.InvestmentsTransactionsGetResponse;
 import com.plaid.client.model.InvestmentsTransactionsGetRequestOptions;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import java.io.IOException;
@@ -15,8 +16,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/investments_transactions")
 @Produces(MediaType.APPLICATION_JSON)
@@ -40,10 +39,9 @@ public class InvestmentTransactionsResource {
       .endDate(endDate)
       .options(options);
 
-    Response<InvestmentsTransactionsGetResponse> response = plaidClient
-      .investmentsTransactionsGet(request)
-      .execute();
-    return new InvestmentTransactionsResponse(response.body());
+    InvestmentsTransactionsGetResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.investmentsTransactionsGet(request));
+    return new InvestmentTransactionsResponse(responseBody);
   }
 
   private static class InvestmentTransactionsResponse {

--- a/java/src/main/java/com/plaid/quickstart/resources/ItemResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/ItemResource.java
@@ -12,14 +12,13 @@ import com.plaid.client.model.InstitutionsGetByIdRequest;
 import com.plaid.client.model.InstitutionsGetByIdResponse;
 import com.plaid.client.model.Institution;
 import com.plaid.client.model.ItemWithConsentFields;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/item")
 @Produces(MediaType.APPLICATION_JSON)
@@ -35,21 +34,19 @@ public class ItemResource {
     ItemGetRequest request = new ItemGetRequest()
       .accessToken(QuickstartApplication.accessToken);
 
-    Response<ItemGetResponse> itemResponse = plaidClient
-    .itemGet(request)
-    .execute();
-    
+    ItemGetResponse itemResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.itemGet(request));
+
     InstitutionsGetByIdRequest institutionsRequest = new InstitutionsGetByIdRequest()
-    .institutionId(itemResponse.body().getItem().getInstitutionId())
+    .institutionId(itemResponseBody.getItem().getInstitutionId())
     .addCountryCodesItem(CountryCode.US);
 
-    Response<InstitutionsGetByIdResponse> institutionsResponse = plaidClient
-    .institutionsGetById(institutionsRequest)
-    .execute();
+    InstitutionsGetByIdResponse institutionsResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.institutionsGetById(institutionsRequest));
 
     return new ItemResponse(
-      itemResponse.body().getItem(), 
-      institutionsResponse.body().getInstitution()
+      itemResponseBody.getItem(),
+      institutionsResponseBody.getInstitution()
     );
   }
 

--- a/java/src/main/java/com/plaid/quickstart/resources/LinkExitErrorResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/LinkExitErrorResource.java
@@ -1,0 +1,28 @@
+package com.plaid.quickstart.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/link_exit_error")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class LinkExitErrorResource {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @POST
+  public Map<String, String> logLinkExitError(Map<String, Object> body) {
+    System.out.println("[Link Exit Error (frontend)]");
+    try {
+      System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(body));
+    } catch (Exception e) {
+      System.out.println(body);
+    }
+    return Map.of("status", "logged");
+  }
+}

--- a/java/src/main/java/com/plaid/quickstart/resources/LinkTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/LinkTokenResource.java
@@ -10,8 +10,8 @@ import com.plaid.client.model.LinkTokenCreateRequestUser;
 import com.plaid.client.model.LinkTokenCreateResponse;
 import com.plaid.client.model.Products;
 import com.plaid.client.request.PlaidApi;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
-import retrofit2.Response;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -20,7 +20,6 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -47,7 +46,6 @@ public class LinkTokenResource {
   public static class LinkToken {
     @JsonProperty
     private String linkToken;
-
 
     public LinkToken(String linkToken) {
       this.linkToken = linkToken;
@@ -101,9 +99,8 @@ public class LinkTokenResource {
       request.craOptions(options);
     }
 
-    	Response<LinkTokenCreateResponse> response =plaidClient
-			.linkTokenCreate(request)
-			.execute();
-    return new LinkToken(response.body().getLinkToken());
+    LinkTokenCreateResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.linkTokenCreate(request));
+    return new LinkToken(responseBody.getLinkToken());
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/LinkTokenWithPaymentResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/LinkTokenWithPaymentResource.java
@@ -16,6 +16,7 @@ import com.plaid.client.model.PaymentInitiationRecipientCreateResponse;
 import com.plaid.client.model.PaymentInitiationAddress;
 import com.plaid.client.model.PaymentInitiationRecipientCreateRequest;
 import com.plaid.client.model.LinkTokenCreateRequestPaymentInitiation;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import java.util.Arrays;
@@ -26,8 +27,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/create_link_token_for_payment")
 @Produces(MediaType.APPLICATION_JSON)
@@ -55,13 +54,10 @@ public class LinkTokenWithPaymentResource {
       .address(address);
 
 
-    Response<PaymentInitiationRecipientCreateResponse> recipientResponse =
-      this.plaidClient
-      .paymentInitiationRecipientCreate(recipientCreateRequest)
-      .execute();
+    PaymentInitiationRecipientCreateResponse recipientResponseBody = PlaidApiHelper.callPlaid(
+      this.plaidClient.paymentInitiationRecipientCreate(recipientCreateRequest));
 
-
-    String recipientId = recipientResponse.body().getRecipientId();
+    String recipientId = recipientResponseBody.getRecipientId();
 
     PaymentAmount amount = new PaymentAmount()
     .currency(PaymentAmountCurrency.GBP)
@@ -72,12 +68,10 @@ public class LinkTokenWithPaymentResource {
       .reference("reference")
       .amount(amount);
 
-    Response<PaymentInitiationPaymentCreateResponse> paymentResponse = plaidClient
-      .paymentInitiationPaymentCreate(paymentCreateRequest)
-      .execute();
+    PaymentInitiationPaymentCreateResponse paymentResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.paymentInitiationPaymentCreate(paymentCreateRequest));
 
-
-    String paymentId = paymentResponse.body().getPaymentId();
+    String paymentId = paymentResponseBody.getPaymentId();
      QuickstartApplication.paymentId = paymentId;
 
     LinkTokenCreateRequestPaymentInitiation paymentInitiation = new LinkTokenCreateRequestPaymentInitiation()
@@ -101,10 +95,8 @@ public class LinkTokenWithPaymentResource {
       .redirectUri(this.redirectUri)
       .paymentInitiation(paymentInitiation);
 
-    	Response<LinkTokenCreateResponse> response =plaidClient
-			.linkTokenCreate(request)
-			.execute();
-
-    return new LinkTokenResource.LinkToken(response.body().getLinkToken());
+    LinkTokenCreateResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.linkTokenCreate(request));
+    return new LinkTokenResource.LinkToken(responseBody.getLinkToken());
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/PaymentInitiationResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/PaymentInitiationResource.java
@@ -3,11 +3,11 @@ package com.plaid.quickstart.resources;
 import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.gson.Gson;
 
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.PaymentInitiationPaymentGetRequest;
 import com.plaid.client.model.PaymentInitiationPaymentGetResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
@@ -15,17 +15,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import retrofit2.Response;
-
 // This functionality is only relevant for the UK Payment Initiation product.
 @Path("/payment")
 @Produces(MediaType.APPLICATION_JSON)
 public class PaymentInitiationResource {
-  private static final Logger LOG = LoggerFactory.getLogger(PaymentInitiationResource.class);
-
   private final PlaidApi plaidClient;
 
   public PaymentInitiationResource(PlaidApi plaidClient) {
@@ -39,20 +32,9 @@ public class PaymentInitiationResource {
     PaymentInitiationPaymentGetRequest request = new PaymentInitiationPaymentGetRequest()
       .paymentId(paymentId);
 
-    Response<PaymentInitiationPaymentGetResponse> response =
-      plaidClient
-      .paymentInitiationPaymentGet(request)
-      .execute();
-    if (!response.isSuccessful()) {
-      try {
-        Gson gson = new Gson();
-        Error errorResponse = gson.fromJson(response.errorBody().string(), Error.class);
-        LOG.error("error: " + errorResponse);
-      } catch (Exception e) {
-          LOG.error("error", e);
-      }
-    }
-    return new PaymentResponse(response.body());
+    PaymentInitiationPaymentGetResponse responseBody = PlaidApiHelper.callPlaid(
+      plaidClient.paymentInitiationPaymentGet(request));
+    return new PaymentResponse(responseBody);
   }
 
   private static class PaymentResponse {

--- a/java/src/main/java/com/plaid/quickstart/resources/PublicTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/PublicTokenResource.java
@@ -6,14 +6,13 @@ import java.io.IOException;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.ItemPublicTokenCreateRequest;
 import com.plaid.client.model.ItemPublicTokenCreateResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/create_public_token")
 @Produces(MediaType.APPLICATION_JSON)
@@ -30,10 +29,6 @@ public class PublicTokenResource {
     ItemPublicTokenCreateRequest request = new ItemPublicTokenCreateRequest() 
     .accessToken(QuickstartApplication.accessToken);
 
-    Response<ItemPublicTokenCreateResponse> response = plaidClient
-      .itemCreatePublicToken(request)
-      .execute();
-
-    return response.body();
+    return PlaidApiHelper.callPlaid(plaidClient.itemCreatePublicToken(request));
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/SignalResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/SignalResource.java
@@ -9,6 +9,7 @@ import com.plaid.client.model.AccountsGetResponse;
 import com.plaid.client.model.AccountIdentity;
 import com.plaid.client.model.SignalEvaluateRequest;
 import com.plaid.client.model.SignalEvaluateResponse;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import java.util.List;
@@ -16,8 +17,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/signal_evaluate")
 @Produces(MediaType.APPLICATION_JSON)
@@ -35,11 +34,10 @@ public class SignalResource {
       AccountsGetRequest accountsGetRequest = new AccountsGetRequest()
         .accessToken(QuickstartApplication.accessToken);
 
-      Response<AccountsGetResponse> accountsGetResponse = plaidClient
-        .accountsGet(accountsGetRequest)
-        .execute();
+      AccountsGetResponse accountsGetResponseBody = PlaidApiHelper.callPlaid(
+        plaidClient.accountsGet(accountsGetRequest));
 
-      QuickstartApplication.accountId = accountsGetResponse.body().getAccounts().get(0).getAccountId();
+      QuickstartApplication.accountId = accountsGetResponseBody.getAccounts().get(0).getAccountId();
 
       // Generate unique transaction ID using timestamp and random component
       String clientTransactionId = String.format("txn-%d-%s",
@@ -56,11 +54,7 @@ public class SignalResource {
         signalEvaluateRequest.rulesetKey(signalRulesetKey);
       }
 
-      Response<SignalEvaluateResponse> signalEvaluateResponse = plaidClient
-        .signalEvaluate(signalEvaluateRequest)
-        .execute();
-
-      return signalEvaluateResponse.body();
+      return PlaidApiHelper.callPlaid(plaidClient.signalEvaluate(signalEvaluateRequest));
 
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
@@ -7,6 +7,7 @@ import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.StatementsListRequest;
 import com.plaid.client.model.StatementsListResponse;
 import com.plaid.client.model.StatementsDownloadRequest;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 import okhttp3.ResponseBody;
 
@@ -18,8 +19,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/statements")
 @Produces(MediaType.APPLICATION_JSON)
@@ -36,22 +35,20 @@ public class StatementsResource {
     StatementsListRequest statementsListRequest = new StatementsListRequest()
       .accessToken(QuickstartApplication.accessToken);
 
-    Response<StatementsListResponse> statementsListResponse = plaidClient
-      .statementsList(statementsListRequest)
-      .execute();
+    StatementsListResponse statementsListResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.statementsList(statementsListRequest));
 
     StatementsDownloadRequest statementsDownloadRequest = new StatementsDownloadRequest()
       .accessToken(QuickstartApplication.accessToken)
-      .statementId(statementsListResponse.body().getAccounts().get(0).getStatements().get(0).getStatementId());
-      
-    Response<ResponseBody> statementsDownloadResponse = plaidClient
-      .statementsDownload(statementsDownloadRequest)
-      .execute();
+      .statementId(statementsListResponseBody.getAccounts().get(0).getStatements().get(0).getStatementId());
 
-    String pdf = Base64.getEncoder().encodeToString(statementsDownloadResponse.body().bytes());
+    ResponseBody statementsDownloadResponseBody = PlaidApiHelper.callPlaid(
+      plaidClient.statementsDownload(statementsDownloadRequest));
+
+    String pdf = Base64.getEncoder().encodeToString(statementsDownloadResponseBody.bytes());
 
     Map<String, Object> responseMap = new HashMap<>();
-    responseMap.put("json", statementsListResponse.body());
+    responseMap.put("json", statementsListResponseBody);
     responseMap.put("pdf", pdf);
 
     return responseMap;

--- a/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/TransactionsResource.java
@@ -12,14 +12,13 @@ import com.plaid.client.model.TransactionsSyncRequest;
 import com.plaid.client.model.TransactionsSyncResponse;
 import com.plaid.client.model.Transaction;
 import com.plaid.client.model.RemovedTransaction;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import retrofit2.Response;
 
 @Path("/transactions")
 @Produces(MediaType.APPLICATION_JSON)
@@ -47,8 +46,8 @@ public class TransactionsResource {
         .accessToken(QuickstartApplication.accessToken)
         .cursor(cursor);
 
-      Response<TransactionsSyncResponse> response = plaidClient.transactionsSync(request).execute();
-      TransactionsSyncResponse responseBody = response.body();
+      TransactionsSyncResponse responseBody = PlaidApiHelper.callPlaid(
+        plaidClient.transactionsSync(request));
 
       cursor = responseBody.getNextCursor();
 

--- a/java/src/main/java/com/plaid/quickstart/resources/TransferAuthorizeResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/TransferAuthorizeResource.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.Transfer;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 import com.plaid.client.model.TransferAuthorizationUserInRequest;
 import com.plaid.client.model.TransferAuthorizationCreateRequest;
@@ -21,11 +22,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import retrofit2.Response;
-
 @Path("/transfer_authorize")
 @Produces(MediaType.APPLICATION_JSON)
 public class TransferAuthorizeResource {
@@ -40,11 +36,10 @@ public class TransferAuthorizeResource {
       AccountsGetRequest accountsGetRequest = new AccountsGetRequest()
         .accessToken(QuickstartApplication.accessToken);
 
-      Response<AccountsGetResponse> accountsGetResponse = plaidClient
-        .accountsGet(accountsGetRequest)
-        .execute();
+      AccountsGetResponse accountsGetResponseBody = PlaidApiHelper.callPlaid(
+        plaidClient.accountsGet(accountsGetRequest));
 
-      QuickstartApplication.accountId = accountsGetResponse.body().getAccounts().get(0).getAccountId();
+      QuickstartApplication.accountId = accountsGetResponseBody.getAccounts().get(0).getAccountId();
 
       TransferAuthorizationUserInRequest user = new TransferAuthorizationUserInRequest()
         .legalName("FirstName LastName");
@@ -58,11 +53,10 @@ public class TransferAuthorizeResource {
         .achClass(ACHClass.PPD)
         .user(user);
 
-      Response<TransferAuthorizationCreateResponse> transferAuthorizationCreateResponse = plaidClient
-        .transferAuthorizationCreate(transferAuthorizationCreateRequest)
-        .execute();
+      TransferAuthorizationCreateResponse responseBody = PlaidApiHelper.callPlaid(
+        plaidClient.transferAuthorizationCreate(transferAuthorizationCreateRequest));
 
-      QuickstartApplication.authorizationId = transferAuthorizationCreateResponse.body().getAuthorization().getId();    
-      return transferAuthorizationCreateResponse.body();
+      QuickstartApplication.authorizationId = responseBody.getAuthorization().getId();
+      return responseBody;
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/TransferCreateResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/TransferCreateResource.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.plaid.client.request.PlaidApi;
 import com.plaid.client.model.Transfer;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
 import com.plaid.client.model.TransferCreateRequest;
 import com.plaid.client.model.TransferCreateResponse;
@@ -14,11 +15,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import retrofit2.Response;
 
 @Path("/transfer_create")
 @Produces(MediaType.APPLICATION_JSON)
@@ -36,9 +32,6 @@ public class TransferCreateResource {
         .accessToken(QuickstartApplication.accessToken)
         .accountId(QuickstartApplication.accountId)
         .description("Debit");
-    Response<TransferCreateResponse> transferCreateResponse = plaidClient 
-      .transferCreate(request)
-      .execute();
-    return transferCreateResponse.body();
+    return PlaidApiHelper.callPlaid(plaidClient.transferCreate(request));
   }
 }

--- a/java/src/main/java/com/plaid/quickstart/resources/UserTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/UserTokenResource.java
@@ -10,8 +10,9 @@ import com.plaid.client.model.ConsumerReportUserIdentity;
 import com.plaid.client.model.UserCreateRequest;
 import com.plaid.client.model.UserCreateResponse;
 import com.plaid.client.request.PlaidApi;
+import com.plaid.quickstart.PlaidApiException;
+import com.plaid.quickstart.PlaidApiHelper;
 import com.plaid.quickstart.QuickstartApplication;
-import retrofit2.Response;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -76,72 +77,48 @@ public class UserTokenResource {
       userCreateRequest.identity(identity);
     }
 
+    UserCreateResponse responseBody;
     try {
-      Response<UserCreateResponse> userResponse = plaidClient.userCreate(userCreateRequest, null).execute();
+      responseBody = PlaidApiHelper.callPlaid(
+        plaidClient.userCreate(userCreateRequest, null));
+    } catch (PlaidApiException e) {
+      // If the error is INVALID_FIELD for CRA products, retry with legacy identity format
+      String errorMessage = e.getErrorResponse().toString();
+      if (errorMessage.contains("INVALID_FIELD") &&
+          plaidProducts.stream().anyMatch(product -> product.startsWith("cra_"))) {
+        UserCreateRequest retryRequest = new UserCreateRequest()
+          .clientUserId(clientUserId);
 
-      // Check if the response was successful
-      if (!userResponse.isSuccessful()) {
-        System.err.println("User create failed with code: " + userResponse.code());
-        if (userResponse.errorBody() != null) {
-          String errorBody = userResponse.errorBody().string();
-          System.err.println("Error body: " + errorBody);
+        AddressData addressData = new AddressData()
+          .city("New York")
+          .region("NY")
+          .street("4 Privet Drive")
+          .postalCode("11111")
+          .country("US");
 
-          if (errorBody.contains("INVALID_FIELD") &&
-              plaidProducts.stream().anyMatch(product -> product.startsWith("cra_"))) {
-            UserCreateRequest retryRequest = new UserCreateRequest()
-              .clientUserId(clientUserId);
+        retryRequest.consumerReportUserIdentity(new ConsumerReportUserIdentity()
+          .dateOfBirth(LocalDate.parse("1980-07-31"))
+          .firstName("Harry")
+          .lastName("Potter")
+          .phoneNumbers(Arrays.asList("+16174567890"))
+          .emails(List.of("harrypotter@example.com"))
+          .primaryAddress(addressData));
 
-            AddressData addressData = new AddressData()
-              .city("New York")
-              .region("NY")
-              .street("4 Privet Drive")
-              .postalCode("11111")
-              .country("US");
-
-            retryRequest.consumerReportUserIdentity(new ConsumerReportUserIdentity()
-              .dateOfBirth(LocalDate.parse("1980-07-31"))
-              .firstName("Harry")
-              .lastName("Potter")
-              .phoneNumbers(Arrays.asList("+16174567890"))
-              .emails(List.of("harrypotter@example.com"))
-              .primaryAddress(addressData));
-
-            Response<UserCreateResponse> retryResponse = plaidClient.userCreate(retryRequest, null).execute();
-
-            // Check if the response was successful
-            if (!retryResponse.isSuccessful()) {
-              System.err.println("User create (retry) failed with code: " + retryResponse.code());
-              if (retryResponse.errorBody() != null) {
-                System.err.println("Error body: " + retryResponse.errorBody().string());
-              }
-              throw new IOException("User create (retry) failed: " + retryResponse.code());
-            }
-
-            // Store both user_token and user_id
-            if (retryResponse.body().getUserToken() != null) {
-              QuickstartApplication.userToken = retryResponse.body().getUserToken();
-            }
-            if (retryResponse.body().getUserId() != null) {
-              QuickstartApplication.userId = retryResponse.body().getUserId();
-            }
-
-            return retryResponse.body();
-          }
-        }
-        throw new IOException("User create failed: " + userResponse.code());
+        responseBody = PlaidApiHelper.callPlaid(
+          plaidClient.userCreate(retryRequest, null));
+      } else {
+        throw e;
       }
-
-      // Store both user_token and user_id
-      if (userResponse.body().getUserToken() != null) {
-        QuickstartApplication.userToken = userResponse.body().getUserToken();
-      }
-      if (userResponse.body().getUserId() != null) {
-        QuickstartApplication.userId = userResponse.body().getUserId();
-      }
-
-      return userResponse.body();
-    } catch (IOException e) {
-      throw e;
     }
+
+    // Store both user_token and user_id
+    if (responseBody.getUserToken() != null) {
+      QuickstartApplication.userToken = responseBody.getUserToken();
+    }
+    if (responseBody.getUserId() != null) {
+      QuickstartApplication.userId = responseBody.getUserId();
+    }
+
+    return responseBody;
   }
 }

--- a/node/index.js
+++ b/node/index.js
@@ -892,8 +892,18 @@ const pollWithRetries = (
       });
   });
 
+app.post('/api/link_exit_error', function (request, response, next) {
+  console.log('[Link Exit Error (frontend)]');
+  console.log(util.inspect(request.body, { colors: true, depth: 4 }));
+  response.json({ status: 'logged' });
+});
+
 app.use('/api', function (error, request, response, next) {
-  console.log(error);
-  prettyPrintResponse(error.response);
-  response.json(formatError(error.response));
+  if (error.response?.data) {
+    prettyPrintResponse(error.response);
+  } else {
+    console.log(error.message || error);
+  }
+  const statusCode = error.response?.status || 500;
+  response.status(statusCode).json(formatError(error.response));
 });

--- a/node/index.js
+++ b/node/index.js
@@ -870,17 +870,22 @@ const pollWithRetries = (
   new Promise((resolve, reject) => {
     requestCallback()
       .then(resolve)
-      .catch(() => {
+      .catch((error) => {
+        const errorCode = error?.response?.data?.error_code;
+        if (errorCode !== 'PRODUCT_NOT_READY') {
+          reject(error);
+          return;
+        }
+        if (retriesLeft === 1) {
+          reject('Ran out of retries while polling');
+          return;
+        }
         setTimeout(() => {
-          if (retriesLeft === 1) {
-            reject('Ran out of retries while polling');
-            return;
-          }
           pollWithRetries(
             requestCallback,
             ms,
             retriesLeft - 1,
-          ).then(resolve);
+          ).then(resolve).catch(reject);
         }, ms);
       });
   });

--- a/node/index.js
+++ b/node/index.js
@@ -872,7 +872,9 @@ const pollWithRetries = (
       .then(resolve)
       .catch((error) => {
         const errorCode = error?.response?.data?.error_code;
-        if (errorCode !== 'PRODUCT_NOT_READY') {
+        const statusCode = error?.response?.status;
+        const isRetryable = errorCode === 'PRODUCT_NOT_READY' || (statusCode >= 500 && statusCode < 600);
+        if (!isRetryable) {
           reject(error);
           return;
         }

--- a/python/server.py
+++ b/python/server.py
@@ -761,12 +761,21 @@ def pretty_print_response(response):
 
 def format_error(e):
     response = json.loads(e.body)
-    return {'error': {'status_code': e.status, 'display_message':
-                      response['error_message'], 'error_code': response['error_code'], 'error_type': response['error_type']}}
+    return {'error': {**response, 'status_code': e.status}}
+
+@app.route('/api/link_exit_error', methods=['POST'])
+def link_exit_error():
+    data = request.get_json()
+    print('[Link Exit Error (frontend)]')
+    pretty_print_response(data)
+    return jsonify({'status': 'logged'})
+
 
 @app.errorhandler(plaid.ApiException)
 def handle_plaid_error(e):
-    return jsonify(format_error(e))
+    response = format_error(e)
+    pretty_print_response(response)
+    return jsonify(response), e.status
 
 if __name__ == '__main__':
     app.run(port=int(os.getenv('PORT', 8000)))

--- a/python/server.py
+++ b/python/server.py
@@ -742,8 +742,12 @@ def poll_with_retries(request_callback, ms=1000, retries_left=20):
         try:
             return request_callback()
         except plaid.ApiException as e:
-            response = json.loads(e.body)
-            is_retryable = response['error_code'] == 'PRODUCT_NOT_READY' or e.status >= 500
+            try:
+                response = json.loads(e.body)
+                error_code = response.get('error_code', '')
+            except (json.JSONDecodeError, TypeError):
+                error_code = ''
+            is_retryable = error_code == 'PRODUCT_NOT_READY' or e.status >= 500
             if not is_retryable:
                 raise e
             elif retries_left == 0:

--- a/python/server.py
+++ b/python/server.py
@@ -148,119 +148,112 @@ def info():
 @app.route('/api/create_link_token_for_payment', methods=['POST'])
 def create_link_token_for_payment():
     global payment_id
-    try:
-        request = PaymentInitiationRecipientCreateRequest(
-            name='John Doe',
-            bacs=RecipientBACSNullable(account='26207729', sort_code='560029'),
-            address=PaymentInitiationAddress(
-                street=['street name 999'],
-                city='city',
-                postal_code='99999',
-                country='GB'
-            )
+    request = PaymentInitiationRecipientCreateRequest(
+        name='John Doe',
+        bacs=RecipientBACSNullable(account='26207729', sort_code='560029'),
+        address=PaymentInitiationAddress(
+            street=['street name 999'],
+            city='city',
+            postal_code='99999',
+            country='GB'
         )
-        response = client.payment_initiation_recipient_create(
-            request)
-        recipient_id = response['recipient_id']
+    )
+    response = client.payment_initiation_recipient_create(
+        request)
+    recipient_id = response['recipient_id']
 
-        request = PaymentInitiationPaymentCreateRequest(
-            recipient_id=recipient_id,
-            reference='TestPayment',
-            amount=PaymentAmount(
-                PaymentAmountCurrency('GBP'),
-                value=100.00
-            )
+    request = PaymentInitiationPaymentCreateRequest(
+        recipient_id=recipient_id,
+        reference='TestPayment',
+        amount=PaymentAmount(
+            PaymentAmountCurrency('GBP'),
+            value=100.00
         )
-        response = client.payment_initiation_payment_create(
-            request
-        )
-        pretty_print_response(response.to_dict())
-        
-        # We store the payment_id in memory for demo purposes - in production, store it in a secure
-        # persistent data store along with the Payment metadata, such as userId.
-        payment_id = response['payment_id']
-        
-        linkRequest = LinkTokenCreateRequest(
-            # The 'payment_initiation' product has to be the only element in the 'products' list.
-            products=[Products('payment_initiation')],
-            client_name='Plaid Test',
-            # Institutions from all listed countries will be shown.
-            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
-            language='en',
-            user=LinkTokenCreateRequestUser(
-                # This should correspond to a unique id for the current user.
-                # Typically, this will be a user ID number from your application.
-                # Personally identifiable information, such as an email address or phone number, should not be used here.
-                client_user_id=str(time.time())
-            ),
-            payment_initiation=LinkTokenCreateRequestPaymentInitiation(
-                payment_id=payment_id
-            )
-        )
+    )
+    response = client.payment_initiation_payment_create(
+        request
+    )
+    pretty_print_response(response.to_dict())
 
-        if PLAID_REDIRECT_URI!=None:
-            linkRequest['redirect_uri']=PLAID_REDIRECT_URI
-        linkResponse = client.link_token_create(linkRequest)
-        pretty_print_response(linkResponse.to_dict())
-        return jsonify(linkResponse.to_dict())
-    except plaid.ApiException as e:
-        return json.loads(e.body)
+    # We store the payment_id in memory for demo purposes - in production, store it in a secure
+    # persistent data store along with the Payment metadata, such as userId.
+    payment_id = response['payment_id']
+
+    linkRequest = LinkTokenCreateRequest(
+        # The 'payment_initiation' product has to be the only element in the 'products' list.
+        products=[Products('payment_initiation')],
+        client_name='Plaid Test',
+        # Institutions from all listed countries will be shown.
+        country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
+        language='en',
+        user=LinkTokenCreateRequestUser(
+            # This should correspond to a unique id for the current user.
+            # Typically, this will be a user ID number from your application.
+            # Personally identifiable information, such as an email address or phone number, should not be used here.
+            client_user_id=str(time.time())
+        ),
+        payment_initiation=LinkTokenCreateRequestPaymentInitiation(
+            payment_id=payment_id
+        )
+    )
+
+    if PLAID_REDIRECT_URI!=None:
+        linkRequest['redirect_uri']=PLAID_REDIRECT_URI
+    linkResponse = client.link_token_create(linkRequest)
+    pretty_print_response(linkResponse.to_dict())
+    return jsonify(linkResponse.to_dict())
 
 
 @app.route('/api/create_link_token', methods=['POST'])
 def create_link_token():
     global user_token
     global user_id
-    try:
-        # Build request based on whether we have user_token or user_id
-        cra_products = ["cra_base_report", "cra_income_insights", "cra_partner_insights"]
-        is_cra = any(product in cra_products for product in PLAID_PRODUCTS)
+    # Build request based on whether we have user_token or user_id
+    cra_products = ["cra_base_report", "cra_income_insights", "cra_partner_insights"]
+    is_cra = any(product in cra_products for product in PLAID_PRODUCTS)
 
-        if is_cra and user_id and not user_token:
-            # For user_id, don't include user field
-            request = LinkTokenCreateRequest(
-                products=products,
-                client_name="Plaid Quickstart",
-                country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
-                language='en'
+    if is_cra and user_id and not user_token:
+        # For user_id, don't include user field
+        request = LinkTokenCreateRequest(
+            products=products,
+            client_name="Plaid Quickstart",
+            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
+            language='en'
+        )
+    else:
+        # For user_token or non-CRA products, include user field
+        request = LinkTokenCreateRequest(
+            products=products,
+            client_name="Plaid Quickstart",
+            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
+            language='en',
+            user=LinkTokenCreateRequestUser(
+                client_user_id=str(time.time())
             )
-        else:
-            # For user_token or non-CRA products, include user field
-            request = LinkTokenCreateRequest(
-                products=products,
-                client_name="Plaid Quickstart",
-                country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES)),
-                language='en',
-                user=LinkTokenCreateRequestUser(
-                    client_user_id=str(time.time())
-                )
-            )
+        )
 
-        if PLAID_REDIRECT_URI!=None:
-            request['redirect_uri']=PLAID_REDIRECT_URI
-        if Products('statements') in products:
-            statements=LinkTokenCreateRequestStatements(
-                end_date=date.today(),
-                start_date=date.today()-timedelta(days=30)
-            )
-            request['statements']=statements
+    if PLAID_REDIRECT_URI!=None:
+        request['redirect_uri']=PLAID_REDIRECT_URI
+    if Products('statements') in products:
+        statements=LinkTokenCreateRequestStatements(
+            end_date=date.today(),
+            start_date=date.today()-timedelta(days=30)
+        )
+        request['statements']=statements
 
-        if is_cra:
-            # Use user_token if available, otherwise use user_id
-            if user_token:
-                request['user_token'] = user_token
-            elif user_id:
-                request['user_id'] = user_id
-            request['consumer_report_permissible_purpose'] = ConsumerReportPermissiblePurpose('ACCOUNT_REVIEW_CREDIT')
-            request['cra_options'] = LinkTokenCreateRequestCraOptions(
-                days_requested=60
-            )
+    if is_cra:
+        # Use user_token if available, otherwise use user_id
+        if user_token:
+            request['user_token'] = user_token
+        elif user_id:
+            request['user_id'] = user_id
+        request['consumer_report_permissible_purpose'] = ConsumerReportPermissiblePurpose('ACCOUNT_REVIEW_CREDIT')
+        request['cra_options'] = LinkTokenCreateRequestCraOptions(
+            days_requested=60
+        )
     # create link token
-        response = client.link_token_create(request)
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        print(e)
-        return json.loads(e.body)
+    response = client.link_token_create(request)
+    return jsonify(response.to_dict())
 
 # Create a user token which can be used for Plaid Check, Income, or Multi-Item link flows
 # https://plaid.com/docs/api/users/#usercreate
@@ -342,11 +335,9 @@ def create_user_token():
                 if 'user_id' in user_response:
                     user_id = user_response['user_id']
                 return jsonify(user_response.to_dict())
-            except plaid.ApiException as retry_error:
-                print(retry_error)
-                return jsonify(json.loads(retry_error.body)), retry_error.status
-        print(e)
-        return jsonify(json.loads(e.body)), e.status
+            except plaid.ApiException:
+                raise
+        raise
 
 
 # Exchange token flow - exchange a Link public_token for
@@ -360,15 +351,12 @@ def get_access_token():
     global item_id
     global transfer_id
     public_token = request.form['public_token']
-    try:
-        exchange_request = ItemPublicTokenExchangeRequest(
-            public_token=public_token)
-        exchange_response = client.item_public_token_exchange(exchange_request)
-        access_token = exchange_response['access_token']
-        item_id = exchange_response['item_id']
-        return jsonify(exchange_response.to_dict())
-    except plaid.ApiException as e:
-        return json.loads(e.body)
+    exchange_request = ItemPublicTokenExchangeRequest(
+        public_token=public_token)
+    exchange_response = client.item_public_token_exchange(exchange_request)
+    access_token = exchange_response['access_token']
+    item_id = exchange_response['item_id']
+    return jsonify(exchange_response.to_dict())
 
 
 # Retrieve ACH or ETF account numbers for an Item
@@ -377,16 +365,12 @@ def get_access_token():
 
 @app.route('/api/auth', methods=['GET'])
 def get_auth():
-    try:
-       request = AuthGetRequest(
-            access_token=access_token
-        )
-       response = client.auth_get(request)
-       pretty_print_response(response.to_dict())
-       return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = AuthGetRequest(
+        access_token=access_token
+    )
+    response = client.auth_get(request)
+    pretty_print_response(response.to_dict())
+    return jsonify(response.to_dict())
 
 
 # Retrieve Transactions for an Item
@@ -403,39 +387,34 @@ def get_transactions():
     modified = []
     removed = [] # Removed transaction ids
     has_more = True
-    try:
-        # Iterate through each page of new transaction updates for item
-        while has_more:
-            request = TransactionsSyncRequest(
-                access_token=access_token,
-                cursor=cursor,
-            )
-            response = client.transactions_sync(request).to_dict()
-            cursor = response['next_cursor']
-            # If no transactions are available yet, wait and poll the endpoint.
-            # Normally, we would listen for a webhook, but the Quickstart doesn't 
-            # support webhooks. For a webhook example, see 
-            # https://github.com/plaid/tutorial-resources or
-            # https://github.com/plaid/pattern
-            if cursor == '':
-                time.sleep(2)
-                continue  
-            # If cursor is not an empty string, we got results, 
-            # so add this page of results
-            added.extend(response['added'])
-            modified.extend(response['modified'])
-            removed.extend(response['removed'])
-            has_more = response['has_more']
-            pretty_print_response(response)
+    # Iterate through each page of new transaction updates for item
+    while has_more:
+        request = TransactionsSyncRequest(
+            access_token=access_token,
+            cursor=cursor,
+        )
+        response = client.transactions_sync(request).to_dict()
+        cursor = response['next_cursor']
+        # If no transactions are available yet, wait and poll the endpoint.
+        # Normally, we would listen for a webhook, but the Quickstart doesn't
+        # support webhooks. For a webhook example, see
+        # https://github.com/plaid/tutorial-resources or
+        # https://github.com/plaid/pattern
+        if cursor == '':
+            time.sleep(2)
+            continue
+        # If cursor is not an empty string, we got results,
+        # so add this page of results
+        added.extend(response['added'])
+        modified.extend(response['modified'])
+        removed.extend(response['removed'])
+        has_more = response['has_more']
+        pretty_print_response(response)
 
-        # Return the 8 most recent transactions
-        latest_transactions = sorted(added, key=lambda t: t['date'])[-8:]
-        return jsonify({
-            'latest_transactions': latest_transactions})
-
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    # Return the 8 most recent transactions
+    latest_transactions = sorted(added, key=lambda t: t['date'])[-8:]
+    return jsonify({
+        'latest_transactions': latest_transactions})
 
 
 # Retrieve Identity data for an Item
@@ -444,17 +423,13 @@ def get_transactions():
 
 @app.route('/api/identity', methods=['GET'])
 def get_identity():
-    try:
-        request = IdentityGetRequest(
-            access_token=access_token
-        )
-        response = client.identity_get(request)
-        pretty_print_response(response.to_dict())
-        return jsonify(
-            {'error': None, 'identity': response.to_dict()['accounts']})
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = IdentityGetRequest(
+        access_token=access_token
+    )
+    response = client.identity_get(request)
+    pretty_print_response(response.to_dict())
+    return jsonify(
+        {'error': None, 'identity': response.to_dict()['accounts']})
 
 
 # Retrieve real-time balance data for each of an Item's accounts
@@ -463,14 +438,10 @@ def get_identity():
 
 @app.route('/api/balance', methods=['GET'])
 def get_balance():
-    try:
-        balance_request = AccountsBalanceGetRequest(access_token=access_token)
-        balance_response = client.accounts_balance_get(balance_request)
-        pretty_print_response(balance_response.to_dict())
-        return jsonify(balance_response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    balance_request = AccountsBalanceGetRequest(access_token=access_token)
+    balance_response = client.accounts_balance_get(balance_request)
+    pretty_print_response(balance_response.to_dict())
+    return jsonify(balance_response.to_dict())
 
 
 # Retrieve an Item's accounts
@@ -479,16 +450,12 @@ def get_balance():
 
 @app.route('/api/accounts', methods=['GET'])
 def get_accounts():
-    try:
-        request = AccountsGetRequest(
-            access_token=access_token
-        )
-        response = client.accounts_get(request)
-        pretty_print_response(response.to_dict())
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = AccountsGetRequest(
+        access_token=access_token
+    )
+    response = client.accounts_get(request)
+    pretty_print_response(response.to_dict())
+    return jsonify(response.to_dict())
 
 
 # Create and then retrieve an Asset Report for one or more Items. Note that an
@@ -499,48 +466,44 @@ def get_accounts():
 
 @app.route('/api/assets', methods=['GET'])
 def get_assets():
-    try:
-        request = AssetReportCreateRequest(
-            access_tokens=[access_token],
-            days_requested=60,
-            options=AssetReportCreateRequestOptions(
-                webhook='https://www.example.com',
-                client_report_id='123',
-                user=AssetReportUser(
-                    client_user_id='789',
-                    first_name='Jane',
-                    middle_name='Leah',
-                    last_name='Doe',
-                    ssn='123-45-6789',
-                    phone_number='(555) 123-4567',
-                    email='jane.doe@example.com',
-                )
+    request = AssetReportCreateRequest(
+        access_tokens=[access_token],
+        days_requested=60,
+        options=AssetReportCreateRequestOptions(
+            webhook='https://www.example.com',
+            client_report_id='123',
+            user=AssetReportUser(
+                client_user_id='789',
+                first_name='Jane',
+                middle_name='Leah',
+                last_name='Doe',
+                ssn='123-45-6789',
+                phone_number='(555) 123-4567',
+                email='jane.doe@example.com',
             )
         )
+    )
 
-        response = client.asset_report_create(request)
-        pretty_print_response(response.to_dict())
-        asset_report_token = response['asset_report_token']
+    response = client.asset_report_create(request)
+    pretty_print_response(response.to_dict())
+    asset_report_token = response['asset_report_token']
 
-        # Poll for the completion of the Asset Report.
-        request = AssetReportGetRequest(
-            asset_report_token=asset_report_token,
-        )
-        response = poll_with_retries(lambda: client.asset_report_get(request))
-        asset_report_json = response['report']
+    # Poll for the completion of the Asset Report.
+    request = AssetReportGetRequest(
+        asset_report_token=asset_report_token,
+    )
+    response = poll_with_retries(lambda: client.asset_report_get(request))
+    asset_report_json = response['report']
 
-        request = AssetReportPDFGetRequest(
-            asset_report_token=asset_report_token,
-        )
-        pdf = client.asset_report_pdf_get(request)
-        return jsonify({
-            'error': None,
-            'json': asset_report_json.to_dict(),
-            'pdf': base64.b64encode(pdf.read()).decode('utf-8'),
-        })
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = AssetReportPDFGetRequest(
+        asset_report_token=asset_report_token,
+    )
+    pdf = client.asset_report_pdf_get(request)
+    return jsonify({
+        'error': None,
+        'json': asset_report_json.to_dict(),
+        'pdf': base64.b64encode(pdf.read()).decode('utf-8'),
+    })
 
 
 # Retrieve investment holdings data for an Item
@@ -549,14 +512,10 @@ def get_assets():
 
 @app.route('/api/holdings', methods=['GET'])
 def get_holdings():
-    try:
-        request = InvestmentsHoldingsGetRequest(access_token=access_token)
-        response = client.investments_holdings_get(request)
-        pretty_print_response(response.to_dict())
-        return jsonify({'error': None, 'holdings': response.to_dict()})
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = InvestmentsHoldingsGetRequest(access_token=access_token)
+    response = client.investments_holdings_get(request)
+    pretty_print_response(response.to_dict())
+    return jsonify({'error': None, 'holdings': response.to_dict()})
 
 
 # Retrieve Investment Transactions for an Item
@@ -569,23 +528,18 @@ def get_investments_transactions():
 
     start_date = (dt.datetime.now() - dt.timedelta(days=(30)))
     end_date = dt.datetime.now()
-    try:
-        options = InvestmentsTransactionsGetRequestOptions()
-        request = InvestmentsTransactionsGetRequest(
-            access_token=access_token,
-            start_date=start_date.date(),
-            end_date=end_date.date(),
-            options=options
-        )
-        response = client.investments_transactions_get(
-            request)
-        pretty_print_response(response.to_dict())
-        return jsonify(
-            {'error': None, 'investments_transactions': response.to_dict()})
-
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    options = InvestmentsTransactionsGetRequestOptions()
+    request = InvestmentsTransactionsGetRequest(
+        access_token=access_token,
+        start_date=start_date.date(),
+        end_date=end_date.date(),
+        options=options
+    )
+    response = client.investments_transactions_get(
+        request)
+    pretty_print_response(response.to_dict())
+    return jsonify(
+        {'error': None, 'investments_transactions': response.to_dict()})
 
 # This functionality is only relevant for the ACH Transfer product.
 # Authorize a transfer
@@ -597,74 +551,58 @@ def transfer_authorization():
     request = AccountsGetRequest(access_token=access_token)
     response = client.accounts_get(request)
     account_id = response['accounts'][0]['account_id']
-    try:
-        request = TransferAuthorizationCreateRequest(
-            access_token=access_token,
-            account_id=account_id,
-            type=TransferType('debit'),
-            network=TransferNetwork('ach'),
-            amount='1.00',
-            ach_class=ACHClass('ppd'),
-            user=TransferAuthorizationUserInRequest(
-                legal_name='FirstName LastName',
-                email_address='foobar@email.com',
-                address=TransferUserAddressInRequest(
-                    street='123 Main St.',
-                    city='San Francisco',
-                    region='CA',
-                    postal_code='94053',
-                    country='US'
-                ),
+    request = TransferAuthorizationCreateRequest(
+        access_token=access_token,
+        account_id=account_id,
+        type=TransferType('debit'),
+        network=TransferNetwork('ach'),
+        amount='1.00',
+        ach_class=ACHClass('ppd'),
+        user=TransferAuthorizationUserInRequest(
+            legal_name='FirstName LastName',
+            email_address='foobar@email.com',
+            address=TransferUserAddressInRequest(
+                street='123 Main St.',
+                city='San Francisco',
+                region='CA',
+                postal_code='94053',
+                country='US'
             ),
-        )
-        response = client.transfer_authorization_create(request)
-        pretty_print_response(response.to_dict())
-        authorization_id = response['authorization']['id']
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+        ),
+    )
+    response = client.transfer_authorization_create(request)
+    pretty_print_response(response.to_dict())
+    authorization_id = response['authorization']['id']
+    return jsonify(response.to_dict())
 
 # Create Transfer for a specified Transfer ID
 
 @app.route('/api/transfer_create', methods=['GET'])
 def transfer():
-    try:
-        request = TransferCreateRequest(
-            access_token=access_token,
-            account_id=account_id,
-            authorization_id=authorization_id,
-            description='Debit')
-        response = client.transfer_create(request)
-        pretty_print_response(response.to_dict())
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = TransferCreateRequest(
+        access_token=access_token,
+        account_id=account_id,
+        authorization_id=authorization_id,
+        description='Debit')
+    response = client.transfer_create(request)
+    pretty_print_response(response.to_dict())
+    return jsonify(response.to_dict())
 
 @app.route('/api/statements', methods=['GET'])
 def statements():
-    try:
-        request = StatementsListRequest(access_token=access_token)
-        response = client.statements_list(request)
-        pretty_print_response(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
-    try:
-        request = StatementsDownloadRequest(
-            access_token=access_token,
-            statement_id=response['accounts'][0]['statements'][0]['statement_id']
-        )
-        pdf = client.statements_download(request)
-        return jsonify({
-            'error': None,
-            'json': response.to_dict(),
-            'pdf': base64.b64encode(pdf.read()).decode('utf-8'),
-        })
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = StatementsListRequest(access_token=access_token)
+    response = client.statements_list(request)
+    pretty_print_response(response.to_dict())
+    request = StatementsDownloadRequest(
+        access_token=access_token,
+        statement_id=response['accounts'][0]['statements'][0]['statement_id']
+    )
+    pdf = client.statements_download(request)
+    return jsonify({
+        'error': None,
+        'json': response.to_dict(),
+        'pdf': base64.b64encode(pdf.read()).decode('utf-8'),
+    })
 
 
 
@@ -675,27 +613,23 @@ def signal():
     request = AccountsGetRequest(access_token=access_token)
     response = client.accounts_get(request)
     account_id = response['accounts'][0]['account_id']
-    try:
-        # Generate unique transaction ID using timestamp and random component
-        client_transaction_id = f"txn-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
+    # Generate unique transaction ID using timestamp and random component
+    client_transaction_id = f"txn-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
 
-        signal_request_params = {
-            'access_token': access_token,
-            'account_id': account_id,
-            'client_transaction_id': client_transaction_id,
-            'amount': 100.00
-        }
+    signal_request_params = {
+        'access_token': access_token,
+        'account_id': account_id,
+        'client_transaction_id': client_transaction_id,
+        'amount': 100.00
+    }
 
-        if SIGNAL_RULESET_KEY:
-            signal_request_params['ruleset_key'] = SIGNAL_RULESET_KEY
+    if SIGNAL_RULESET_KEY:
+        signal_request_params['ruleset_key'] = SIGNAL_RULESET_KEY
 
-        request = SignalEvaluateRequest(**signal_request_params)
-        response = client.signal_evaluate(request)
-        pretty_print_response(response.to_dict())
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = SignalEvaluateRequest(**signal_request_params)
+    response = client.signal_evaluate(request)
+    pretty_print_response(response.to_dict())
+    return jsonify(response.to_dict())
 
 
 # This functionality is only relevant for the UK Payment Initiation product.
@@ -705,14 +639,10 @@ def signal():
 @app.route('/api/payment', methods=['GET'])
 def payment():
     global payment_id
-    try:
-        request = PaymentInitiationPaymentGetRequest(payment_id=payment_id)
-        response = client.payment_initiation_payment_get(request)
-        pretty_print_response(response.to_dict())
-        return jsonify({'error': None, 'payment': response.to_dict()})
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = PaymentInitiationPaymentGetRequest(payment_id=payment_id)
+    response = client.payment_initiation_payment_get(request)
+    pretty_print_response(response.to_dict())
+    return jsonify({'error': None, 'payment': response.to_dict()})
 
 
 # Retrieve high-level information about an Item
@@ -721,102 +651,86 @@ def payment():
 
 @app.route('/api/item', methods=['GET'])
 def item():
-    try:
-        request = ItemGetRequest(access_token=access_token)
-        response = client.item_get(request)
-        request = InstitutionsGetByIdRequest(
-            institution_id=response['item']['institution_id'],
-            country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES))
-        )
-        institution_response = client.institutions_get_by_id(request)
-        pretty_print_response(response.to_dict())
-        pretty_print_response(institution_response.to_dict())
-        return jsonify({'error': None, 'item': response.to_dict()[
-            'item'], 'institution': institution_response.to_dict()['institution']})
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    request = ItemGetRequest(access_token=access_token)
+    response = client.item_get(request)
+    request = InstitutionsGetByIdRequest(
+        institution_id=response['item']['institution_id'],
+        country_codes=list(map(lambda x: CountryCode(x), PLAID_COUNTRY_CODES))
+    )
+    institution_response = client.institutions_get_by_id(request)
+    pretty_print_response(response.to_dict())
+    pretty_print_response(institution_response.to_dict())
+    return jsonify({'error': None, 'item': response.to_dict()[
+        'item'], 'institution': institution_response.to_dict()['institution']})
 
 # Retrieve CRA Base Report and PDF
 # Base report: https://plaid.com/docs/check/api/#cracheck_reportbase_reportget
 # PDF: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 @app.route('/api/cra/get_base_report', methods=['GET'])
 def cra_check_report():
-    try:
-        # Use user_token if available, otherwise use user_id
-        if user_token:
-            base_report_request = CraCheckReportBaseReportGetRequest(user_token=user_token, item_ids=[])
-        elif user_id:
-            base_report_request = CraCheckReportBaseReportGetRequest(user_id=user_id, item_ids=[])
+    # Use user_token if available, otherwise use user_id
+    if user_token:
+        base_report_request = CraCheckReportBaseReportGetRequest(user_token=user_token, item_ids=[])
+    elif user_id:
+        base_report_request = CraCheckReportBaseReportGetRequest(user_id=user_id, item_ids=[])
 
-        get_response = poll_with_retries(lambda: client.cra_check_report_base_report_get(base_report_request))
-        pretty_print_response(get_response.to_dict())
+    get_response = poll_with_retries(lambda: client.cra_check_report_base_report_get(base_report_request))
+    pretty_print_response(get_response.to_dict())
 
-        if user_token:
-            pdf_request = CraCheckReportPDFGetRequest(user_token=user_token)
-        elif user_id:
-            pdf_request = CraCheckReportPDFGetRequest(user_id=user_id)
+    if user_token:
+        pdf_request = CraCheckReportPDFGetRequest(user_token=user_token)
+    elif user_id:
+        pdf_request = CraCheckReportPDFGetRequest(user_id=user_id)
 
-        pdf_response = client.cra_check_report_pdf_get(pdf_request)
+    pdf_response = client.cra_check_report_pdf_get(pdf_request)
 
-        return jsonify({
-            'report': get_response.to_dict()['report'],
-            'pdf': base64.b64encode(pdf_response.read()).decode('utf-8')
-        })
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    return jsonify({
+        'report': get_response.to_dict()['report'],
+        'pdf': base64.b64encode(pdf_response.read()).decode('utf-8')
+    })
 
 # Retrieve CRA Income Insights and PDF with Insights
 # Income insights: https://plaid.com/docs/check/api/#cracheck_reportincome_insightsget
 # PDF w/ income insights: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 @app.route('/api/cra/get_income_insights', methods=['GET'])
 def cra_income_insights():
-    try:
-        # Use user_token if available, otherwise use user_id
-        insights_request = {}
-        if user_token:
-            insights_request = CraCheckReportIncomeInsightsGetRequest(user_token=user_token)
-        elif user_id:
-            insights_request = CraCheckReportIncomeInsightsGetRequest(user_id=user_id)
+    # Use user_token if available, otherwise use user_id
+    insights_request = {}
+    if user_token:
+        insights_request = CraCheckReportIncomeInsightsGetRequest(user_token=user_token)
+    elif user_id:
+        insights_request = CraCheckReportIncomeInsightsGetRequest(user_id=user_id)
 
-        get_response = poll_with_retries(lambda: client.cra_check_report_income_insights_get(insights_request))
-        pretty_print_response(get_response.to_dict())
+    get_response = poll_with_retries(lambda: client.cra_check_report_income_insights_get(insights_request))
+    pretty_print_response(get_response.to_dict())
 
-        pdf_request = {}
-        if user_token:
-            pdf_request = CraCheckReportPDFGetRequest(user_token=user_token, add_ons=[CraPDFAddOns('cra_income_insights')])
-        elif user_id:
-            pdf_request = CraCheckReportPDFGetRequest(user_id=user_id, add_ons=[CraPDFAddOns('cra_income_insights')])
+    pdf_request = {}
+    if user_token:
+        pdf_request = CraCheckReportPDFGetRequest(user_token=user_token, add_ons=[CraPDFAddOns('cra_income_insights')])
+    elif user_id:
+        pdf_request = CraCheckReportPDFGetRequest(user_id=user_id, add_ons=[CraPDFAddOns('cra_income_insights')])
 
-        pdf_response = client.cra_check_report_pdf_get(pdf_request)
+    pdf_response = client.cra_check_report_pdf_get(pdf_request)
 
-        return jsonify({
-            'report': get_response.to_dict()['report'],
-            'pdf': base64.b64encode(pdf_response.read()).decode('utf-8')
-        })
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    return jsonify({
+        'report': get_response.to_dict()['report'],
+        'pdf': base64.b64encode(pdf_response.read()).decode('utf-8')
+    })
 
 # Retrieve CRA Partner Insights
 # https://plaid.com/docs/check/api/#cracheck_reportpartner_insightsget
 @app.route('/api/cra/get_partner_insights', methods=['GET'])
 def cra_partner_insights():
-    try:
-        # Use user_token if available, otherwise use user_id
-        if user_token:
-            partner_request = CraCheckReportPartnerInsightsGetRequest(user_token=user_token)
-        elif user_id:
-            partner_request = CraCheckReportPartnerInsightsGetRequest(user_id=user_id)
+    # Use user_token if available, otherwise use user_id
+    if user_token:
+        partner_request = CraCheckReportPartnerInsightsGetRequest(user_token=user_token)
+    elif user_id:
+        partner_request = CraCheckReportPartnerInsightsGetRequest(user_id=user_id)
 
-        response = poll_with_retries(lambda: client.cra_check_report_partner_insights_get(partner_request))
-        pretty_print_response(response.to_dict())
+    response = poll_with_retries(lambda: client.cra_check_report_partner_insights_get(partner_request))
+    pretty_print_response(response.to_dict())
 
-        return jsonify(response.to_dict())
-    except plaid.ApiException as e:
-        error_response = format_error(e)
-        return jsonify(error_response)
+    return jsonify(response.to_dict())
 
 # Since this quickstart does not support webhooks, this function can be used to poll
 # an API that would otherwise be triggered by a webhook.
@@ -844,6 +758,10 @@ def format_error(e):
     response = json.loads(e.body)
     return {'error': {'status_code': e.status, 'display_message':
                       response['error_message'], 'error_code': response['error_code'], 'error_type': response['error_type']}}
+
+@app.errorhandler(plaid.ApiException)
+def handle_plaid_error(e):
+    return jsonify(format_error(e))
 
 if __name__ == '__main__':
     app.run(port=int(os.getenv('PORT', 8000)))

--- a/python/server.py
+++ b/python/server.py
@@ -743,7 +743,8 @@ def poll_with_retries(request_callback, ms=1000, retries_left=20):
             return request_callback()
         except plaid.ApiException as e:
             response = json.loads(e.body)
-            if response['error_code'] != 'PRODUCT_NOT_READY':
+            is_retryable = response['error_code'] == 'PRODUCT_NOT_READY' or e.status >= 500
+            if not is_retryable:
                 raise e
             elif retries_left == 0:
                 raise Exception('Ran out of retries while polling') from e

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -76,162 +76,113 @@ end
 # Retrieve Transactions for an Item
 # https://plaid.com/docs/#transactions
 get '/api/transactions' do
-  begin
-    # Set cursor to empty to receive all historical updates
-    cursor = ''
+  # Set cursor to empty to receive all historical updates
+  cursor = ''
 
-    # New transaction updates since "cursor"
-    added = []
-    modified = []
-    removed = [] # Removed transaction ids
-    has_more = true
-    # Iterate through each page of new transaction updates for item
-    while has_more
-      request = Plaid::TransactionsSyncRequest.new(
-        {
-          access_token: access_token,
-          cursor: cursor
-        }
-      )
-      response = client.transactions_sync(request)
-      cursor = response.next_cursor
+  # New transaction updates since "cursor"
+  added = []
+  modified = []
+  removed = [] # Removed transaction ids
+  has_more = true
+  # Iterate through each page of new transaction updates for item
+  while has_more
+    request = Plaid::TransactionsSyncRequest.new(
+      {
+        access_token: access_token,
+        cursor: cursor
+      }
+    )
+    response = client.transactions_sync(request)
+    cursor = response.next_cursor
 
-      # If no transactions are available yet, wait and poll the endpoint.
-      # Normally, we would listen for a webhook but the Quickstart doesn't 
-      # support webhooks. For a webhook example, see 
-      # https://github.com/plaid/tutorial-resources or
-      # https://github.com/plaid/pattern
-      if cursor == ""
-        sleep 2 
-        next 
-      end
-    
-      # Add this page of results
-      added += response.added
-      modified += response.modified
-      removed += response.removed
-      has_more = response.has_more
-      pretty_print_response(response.to_hash)
+    # If no transactions are available yet, wait and poll the endpoint.
+    # Normally, we would listen for a webhook but the Quickstart doesn't
+    # support webhooks. For a webhook example, see
+    # https://github.com/plaid/tutorial-resources or
+    # https://github.com/plaid/pattern
+    if cursor == ""
+      sleep 2
+      next
     end
-    # Return the 8 most recent transactions
-    content_type :json
-    { latest_transactions: added.sort_by(&:date).last(8).map(&:to_hash) }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
+
+    # Add this page of results
+    added += response.added
+    modified += response.modified
+    removed += response.removed
+    has_more = response.has_more
+    pretty_print_response(response.to_hash)
   end
+  # Return the 8 most recent transactions
+  content_type :json
+  { latest_transactions: added.sort_by(&:date).last(8).map(&:to_hash) }.to_json
 end
 
 # Retrieve ACH or ETF account numbers for an Item
 # https://plaid.com/docs/#auth
 get '/api/auth' do
-  begin
-    auth_get_request = Plaid::AuthGetRequest.new({ access_token: access_token })
-    auth_response = client.auth_get(auth_get_request)
-    pretty_print_response(auth_response.to_hash)
-    content_type :json
-    auth_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  auth_get_request = Plaid::AuthGetRequest.new({ access_token: access_token })
+  auth_response = client.auth_get(auth_get_request)
+  pretty_print_response(auth_response.to_hash)
+  content_type :json
+  auth_response.to_hash.to_json
 end
 
 # Retrieve Identity data for an Item
 # https://plaid.com/docs/#identity
 get '/api/identity' do
-  begin
-    identity_get_request = Plaid::IdentityGetRequest.new({ access_token: access_token })
-    identity_response = client.identity_get(identity_get_request)
-    pretty_print_response(identity_response.to_hash)
-    content_type :json
-    { identity: identity_response.to_hash[:accounts] }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  identity_get_request = Plaid::IdentityGetRequest.new({ access_token: access_token })
+  identity_response = client.identity_get(identity_get_request)
+  pretty_print_response(identity_response.to_hash)
+  content_type :json
+  { identity: identity_response.to_hash[:accounts] }.to_json
 end
 
 # Retrieve real-time balance data for each of an Item's accounts
 # https://plaid.com/docs/#balance
 get '/api/balance' do
-  begin
-    balance_request = Plaid::AccountsBalanceGetRequest.new({ access_token: access_token })
-    balance_response = client.accounts_balance_get(balance_request)
-    pretty_print_response(balance_response.to_hash)
-    content_type :json
-    balance_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  balance_request = Plaid::AccountsBalanceGetRequest.new({ access_token: access_token })
+  balance_response = client.accounts_balance_get(balance_request)
+  pretty_print_response(balance_response.to_hash)
+  content_type :json
+  balance_response.to_hash.to_json
 end
 
 # Retrieve an Item's accounts
 # https://plaid.com/docs/#accounts
 get '/api/accounts' do
-  begin
-    accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
-    account_response = client.accounts_get(accounts_get_request)
-    pretty_print_response(account_response.to_hash)
-    content_type :json
-    account_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
+  account_response = client.accounts_get(accounts_get_request)
+  pretty_print_response(account_response.to_hash)
+  content_type :json
+  account_response.to_hash.to_json
 end
 
 # Retrieve Holdings data for an Item
 # https://plaid.com/docs/#investments
 get '/api/holdings' do
-  begin
-    investments_holdings_get_request = Plaid::InvestmentsHoldingsGetRequest.new({ access_token: access_token })
-    product_response = client.investments_holdings_get(investments_holdings_get_request)
-    pretty_print_response(product_response.to_hash)
-    content_type :json
-    { holdings: product_response.to_hash }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_hash.to_json
-  end
+  investments_holdings_get_request = Plaid::InvestmentsHoldingsGetRequest.new({ access_token: access_token })
+  product_response = client.investments_holdings_get(investments_holdings_get_request)
+  pretty_print_response(product_response.to_hash)
+  content_type :json
+  { holdings: product_response.to_hash }.to_json
 end
 
 # Retrieve Investment Transactions for an Item
 # https://plaid.com/docs/#investments
 get '/api/investments_transactions' do
-  begin
-    start_date = (Date.today - 30)
-    end_date = Date.today
-    investments_transactions_get_request = Plaid::InvestmentsTransactionsGetRequest.new(
-      {
-        access_token: access_token,
-        start_date: start_date,
-        end_date: end_date
-      }
-    )
-    transactions_response = client.investments_transactions_get(investments_transactions_get_request)
-    pretty_print_response(transactions_response.to_hash)
-    content_type :json
-    { investments_transactions: transactions_response.to_hash }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  start_date = (Date.today - 30)
+  end_date = Date.today
+  investments_transactions_get_request = Plaid::InvestmentsTransactionsGetRequest.new(
+    {
+      access_token: access_token,
+      start_date: start_date,
+      end_date: end_date
+    }
+  )
+  transactions_response = client.investments_transactions_get(investments_transactions_get_request)
+  pretty_print_response(transactions_response.to_hash)
+  content_type :json
+  { investments_transactions: transactions_response.to_hash }.to_json
 end
 
 # Create and then retrieve an Asset Report for one or more Items. Note that an
@@ -240,36 +191,29 @@ end
 # https://plaid.com/docs/#assets
 # rubocop:disable Metrics/BlockLength
 get '/api/assets' do
-  begin
-    options = {
-      client_report_id: '123',
-      webhook: 'https://www.example.com',
-      user: {
-        client_user_id: '789',
-        first_name: 'Jane',
-        middle_name: 'Leah',
-        last_name: 'Doe',
-        ssn: '123-45-6789',
-        phone_number: '(555) 123-4567',
-        email: 'jane.doe@example.com'
-      }
+  options = {
+    client_report_id: '123',
+    webhook: 'https://www.example.com',
+    user: {
+      client_user_id: '789',
+      first_name: 'Jane',
+      middle_name: 'Leah',
+      last_name: 'Doe',
+      ssn: '123-45-6789',
+      phone_number: '(555) 123-4567',
+      email: 'jane.doe@example.com'
     }
-    asset_report_create_request = Plaid::AssetReportCreateRequest.new(
-      {
-        access_tokens: [access_token],
-        days_requested: 20,
-        options: options
-      }
-    )
-    asset_report_create_response =
-      client.asset_report_create(asset_report_create_request)
-    pretty_print_response(asset_report_create_response.to_hash)
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  }
+  asset_report_create_request = Plaid::AssetReportCreateRequest.new(
+    {
+      access_tokens: [access_token],
+      days_requested: 20,
+      options: options
+    }
+  )
+  asset_report_create_response =
+    client.asset_report_create(asset_report_create_request)
+  pretty_print_response(asset_report_create_response.to_hash)
 
   asset_report_token = asset_report_create_response.asset_report_token
   asset_report_json = nil
@@ -287,10 +231,7 @@ get '/api/assets' do
         sleep(1)
         next
       end
-      error_response = format_error(e)
-      pretty_print_response(error_response)
-      content_type :json
-      return error_response.to_json
+      raise
     end
   end
 
@@ -313,21 +254,15 @@ get '/api/assets' do
 end
 
 get '/api/statements' do
-  begin
-    statements_list_request = Plaid::StatementsListRequest.new(
-      {
-        access_token: access_token
-      }
-    )
-    statements_list_response =
-      client.statements_list(statements_list_request)
-    pretty_print_response(statements_list_response.to_hash)
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  statements_list_request = Plaid::StatementsListRequest.new(
+    {
+      access_token: access_token
+    }
+  )
+  statements_list_response =
+    client.statements_list(statements_list_request)
+  pretty_print_response(statements_list_response.to_hash)
+
   statement_id = statements_list_response.accounts[0].statements[0].statement_id
   statements_download_request = Plaid::StatementsDownloadRequest.new({ access_token: access_token, statement_id: statement_id })
   statement_pdf = client.statements_download(statements_download_request)
@@ -342,275 +277,226 @@ end
 # Retrieve high-level information about an Item
 # https://plaid.com/docs/#retrieve-item
 get '/api/item' do
-  begin
-    item_get_request = Plaid::ItemGetRequest.new({ access_token: access_token})
-    item_response = client.item_get(item_get_request)
-    institutions_get_by_id_request = Plaid::InstitutionsGetByIdRequest.new(
-      {
-        institution_id: item_response.item.institution_id,
-        country_codes: ['US']
-      }
-    )
-    institution_response =
-      client.institutions_get_by_id(institutions_get_by_id_request)
-    pretty_print_response(item_response.to_hash)
-    pretty_print_response(institution_response.to_hash)
-    content_type :json
-    { item: item_response.item.to_hash,
-      institution: institution_response.institution.to_hash }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  item_get_request = Plaid::ItemGetRequest.new({ access_token: access_token})
+  item_response = client.item_get(item_get_request)
+  institutions_get_by_id_request = Plaid::InstitutionsGetByIdRequest.new(
+    {
+      institution_id: item_response.item.institution_id,
+      country_codes: ['US']
+    }
+  )
+  institution_response =
+    client.institutions_get_by_id(institutions_get_by_id_request)
+  pretty_print_response(item_response.to_hash)
+  pretty_print_response(institution_response.to_hash)
+  content_type :json
+  { item: item_response.item.to_hash,
+    institution: institution_response.institution.to_hash }.to_json
 end
 
 # This functionality is only relevant for the ACH Transfer product.
 # Retrieve Transfer for a specified Transfer ID
 
 get '/api/transfer_authorize' do
-  begin
-    # We call /accounts/get to obtain first account_id - in production,
-    # account_id's should be persisted in a data store and retrieved
-    # from there.
-    accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
-    accounts_get_response = client.accounts_get(accounts_get_request)
-    account_id = accounts_get_response.accounts[0].account_id
+  # We call /accounts/get to obtain first account_id - in production,
+  # account_id's should be persisted in a data store and retrieved
+  # from there.
+  accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
+  accounts_get_response = client.accounts_get(accounts_get_request)
+  account_id = accounts_get_response.accounts[0].account_id
 
-    transfer_authorization_create_request = Plaid::TransferAuthorizationCreateRequest.new({
-      access_token: access_token,
-      account_id: account_id,
-      type: 'debit',
-      network: 'ach',
-      amount: '1.00',
-      ach_class: 'ppd',
-      user: {
-        legal_name: 'FirstName LastName',
-        email_address: 'foobar@email.com',
-        address: {
-          street: '123 Main St.',
-          city: 'San Francisco',
-          region: 'CA',
-          postal_code: '94053',
-          country: 'US'
-        }
-      },
-    })
-    transfer_authorization_create_response = client.transfer_authorization_create(transfer_authorization_create_request)
-    pretty_print_response(transfer_authorization_create_response.to_hash)
-    authorization_id = transfer_authorization_create_response.authorization.id
-    content_type :json
-    transfer_authorization_create_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  transfer_authorization_create_request = Plaid::TransferAuthorizationCreateRequest.new({
+    access_token: access_token,
+    account_id: account_id,
+    type: 'debit',
+    network: 'ach',
+    amount: '1.00',
+    ach_class: 'ppd',
+    user: {
+      legal_name: 'FirstName LastName',
+      email_address: 'foobar@email.com',
+      address: {
+        street: '123 Main St.',
+        city: 'San Francisco',
+        region: 'CA',
+        postal_code: '94053',
+        country: 'US'
+      }
+    },
+  })
+  transfer_authorization_create_response = client.transfer_authorization_create(transfer_authorization_create_request)
+  pretty_print_response(transfer_authorization_create_response.to_hash)
+  authorization_id = transfer_authorization_create_response.authorization.id
+  content_type :json
+  transfer_authorization_create_response.to_hash.to_json
 end
 
 get '/api/signal_evaluate' do
-  begin
-    # We call /accounts/get to obtain first account_id - in production,
-    # account_id's should be persisted in a data store and retrieved
-    # from there.
-    accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
-    accounts_get_response = client.accounts_get(accounts_get_request)
-    account_id = accounts_get_response.accounts[0].account_id
+  # We call /accounts/get to obtain first account_id - in production,
+  # account_id's should be persisted in a data store and retrieved
+  # from there.
+  accounts_get_request = Plaid::AccountsGetRequest.new({ access_token: access_token })
+  accounts_get_response = client.accounts_get(accounts_get_request)
+  account_id = accounts_get_response.accounts[0].account_id
 
-    # Generate unique transaction ID using timestamp and random component
-    client_transaction_id = "txn-#{Time.now.to_i}-#{SecureRandom.hex(4)}"
+  # Generate unique transaction ID using timestamp and random component
+  client_transaction_id = "txn-#{Time.now.to_i}-#{SecureRandom.hex(4)}"
 
-    signal_request_params = {
-      access_token: access_token,
-      account_id: account_id,
-      client_transaction_id: client_transaction_id,
-      amount: 100.00
-    }
+  signal_request_params = {
+    access_token: access_token,
+    account_id: account_id,
+    client_transaction_id: client_transaction_id,
+    amount: 100.00
+  }
 
-    if ENV['SIGNAL_RULESET_KEY'] && !ENV['SIGNAL_RULESET_KEY'].empty?
-      signal_request_params[:ruleset_key] = ENV['SIGNAL_RULESET_KEY']
-    end
-
-    signal_evaluate_request = Plaid::SignalEvaluateRequest.new(signal_request_params)
-    signal_evaluate_response = client.signal_evaluate(signal_evaluate_request)
-    pretty_print_response(signal_evaluate_response.to_hash)
-    content_type :json
-    signal_evaluate_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
+  if ENV['SIGNAL_RULESET_KEY'] && !ENV['SIGNAL_RULESET_KEY'].empty?
+    signal_request_params[:ruleset_key] = ENV['SIGNAL_RULESET_KEY']
   end
+
+  signal_evaluate_request = Plaid::SignalEvaluateRequest.new(signal_request_params)
+  signal_evaluate_response = client.signal_evaluate(signal_evaluate_request)
+  pretty_print_response(signal_evaluate_response.to_hash)
+  content_type :json
+  signal_evaluate_response.to_hash.to_json
 end
 
 get '/api/transfer_create' do
-  begin
-      transfer_create_request = Plaid::TransferCreateRequest.new({
-      access_token: access_token,
-      account_id: account_id,
-      authorization_id: authorization_id,
-      description: 'Debit'
-    })
-    transfer_create_response = client.transfer_create(transfer_create_request)
-    pretty_print_response(transfer_create_response.to_hash)
-    content_type :json
-    transfer_create_response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  transfer_create_request = Plaid::TransferCreateRequest.new({
+    access_token: access_token,
+    account_id: account_id,
+    authorization_id: authorization_id,
+    description: 'Debit'
+  })
+  transfer_create_response = client.transfer_create(transfer_create_request)
+  pretty_print_response(transfer_create_response.to_hash)
+  content_type :json
+  transfer_create_response.to_hash.to_json
 end
 
 # This functionality is only relevant for the UK Payment Initiation product.
 # Retrieve Payment for a specified Payment ID
 get '/api/payment' do
-  begin
-    payment_initiation_payment_get_request = Plaid::PaymentInitiationPaymentGetRequest.new({ payment_id: payment_id})
-    payment_get_response = client.payment_initiation_payment_get(payment_initiation_payment_get_request)
-    pretty_print_response(payment_get_response.to_hash)
-    content_type :json
-    { payment: payment_get_response.to_hash}.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  payment_initiation_payment_get_request = Plaid::PaymentInitiationPaymentGetRequest.new({ payment_id: payment_id})
+  payment_get_response = client.payment_initiation_payment_get(payment_initiation_payment_get_request)
+  pretty_print_response(payment_get_response.to_hash)
+  content_type :json
+  { payment: payment_get_response.to_hash}.to_json
 end
 
 post '/api/create_link_token' do
-  begin
-    link_token_create_request = Plaid::LinkTokenCreateRequest.new(
-      {
-        user: { client_user_id: 'user-id' },
-        client_name: 'Plaid Quickstart',
-        products: ENV['PLAID_PRODUCTS'].split(','),
-        country_codes: ENV['PLAID_COUNTRY_CODES'].split(','),
-        language: 'en',
-        redirect_uri: nil_if_empty_envvar('PLAID_REDIRECT_URI')
-      }
+  link_token_create_request = Plaid::LinkTokenCreateRequest.new(
+    {
+      user: { client_user_id: 'user-id' },
+      client_name: 'Plaid Quickstart',
+      products: ENV['PLAID_PRODUCTS'].split(','),
+      country_codes: ENV['PLAID_COUNTRY_CODES'].split(','),
+      language: 'en',
+      redirect_uri: nil_if_empty_envvar('PLAID_REDIRECT_URI')
+    }
+  )
+  if ENV['PLAID_PRODUCTS'].split(',').include?("statements")
+    today = Date.today
+    statements = Plaid::LinkTokenCreateRequestStatements.new(
+      end_date: today,
+      start_date: today-30
     )
-    if ENV['PLAID_PRODUCTS'].split(',').include?("statements")
-      today = Date.today
-      statements = Plaid::LinkTokenCreateRequestStatements.new(
-        end_date: today,
-        start_date: today-30
-      )
-      link_token_create_request.statements=statements
-    end
-    if products.any? { |product| product.start_with?("cra_") }
-      link_token_create_request.cra_options = Plaid::LinkTokenCreateRequestCraOptions.new(
-        days_requested: 60
-      )
-      # Use user_token if available, otherwise use user_id
-      if user_token
-        link_token_create_request.user_token = user_token
-        # Keep user object when using user_token
-      elsif user_id
-        link_token_create_request.user_id = user_id
-        # Remove user object when using user_id
-        link_token_create_request.user = nil
-      end
-      link_token_create_request.consumer_report_permissible_purpose = Plaid::ConsumerReportPermissiblePurpose::ACCOUNT_REVIEW_CREDIT
-    end
-    link_response = client.link_token_create(link_token_create_request)
-    pretty_print_response(link_response.to_hash)
-    content_type :json
-    { link_token: link_response.link_token }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
+    link_token_create_request.statements=statements
   end
+  if products.any? { |product| product.start_with?("cra_") }
+    link_token_create_request.cra_options = Plaid::LinkTokenCreateRequestCraOptions.new(
+      days_requested: 60
+    )
+    # Use user_token if available, otherwise use user_id
+    if user_token
+      link_token_create_request.user_token = user_token
+      # Keep user object when using user_token
+    elsif user_id
+      link_token_create_request.user_id = user_id
+      # Remove user object when using user_id
+      link_token_create_request.user = nil
+    end
+    link_token_create_request.consumer_report_permissible_purpose = Plaid::ConsumerReportPermissiblePurpose::ACCOUNT_REVIEW_CREDIT
+  end
+  link_response = client.link_token_create(link_token_create_request)
+  pretty_print_response(link_response.to_hash)
+  content_type :json
+  { link_token: link_response.link_token }.to_json
 end
 
 # Create a user token which can be used for Plaid Check, Income, or Multi-Item link flows
 # https://plaid.com/docs/api/users/#usercreate
 post '/api/create_user_token' do
-  begin
-    client_user_id = 'user_' + SecureRandom.uuid
+  client_user_id = 'user_' + SecureRandom.uuid
 
-    request_data = {
-      # Typically this will be a user ID number from your application.
-      client_user_id: client_user_id
+  request_data = {
+    # Typically this will be a user ID number from your application.
+    client_user_id: client_user_id
+  }
+
+  if products.any? { |product| product.start_with?("cra_") }
+    # Try with Identity field first (new-style)
+    request_data[:identity] = {
+      name: {
+        given_name: 'Harry',
+        family_name: 'Potter'
+      },
+      date_of_birth: '1980-07-31',
+      phone_numbers: [{
+        data: '+16174567890',
+        primary: true
+      }],
+      emails: [{
+        data: 'harrypotter@example.com',
+        primary: true
+      }],
+      addresses: [{
+        street_1: '4 Privet Drive',
+        city: 'New York',
+        region: 'NY',
+        postal_code: '11111',
+        country: 'US',
+        primary: true
+      }]
     }
+  end
 
-    if products.any? { |product| product.start_with?("cra_") }
-      # Try with Identity field first (new-style)
-      request_data[:identity] = {
-        name: {
-          given_name: 'Harry',
-          family_name: 'Potter'
-        },
-        date_of_birth: '1980-07-31',
-        phone_numbers: [{
-          data: '+16174567890',
-          primary: true
-        }],
-        emails: [{
-          data: 'harrypotter@example.com',
-          primary: true
-        }],
-        addresses: [{
-          street_1: '4 Privet Drive',
-          city: 'New York',
-          region: 'NY',
-          postal_code: '11111',
-          country: 'US',
-          primary: true
-        }]
+  begin
+    user = client.user_create(Plaid::UserCreateRequest.new(request_data))
+    # Store both user_token and user_id
+    user_token = user.user_token if user.user_token
+    user_id = user.user_id if user.user_id
+    content_type :json
+    user.to_hash.to_json
+  rescue Plaid::ApiError => e
+    error_body = JSON.parse(e.response_body) rescue {}
+    if error_body['error_code'] == 'INVALID_FIELD' &&
+       products.any? { |product| product.start_with?("cra_") }
+      retry_request_data = {
+        client_user_id: client_user_id,
+        consumer_report_user_identity: {
+          first_name: 'Harry',
+          last_name: 'Potter',
+          date_of_birth: '1980-07-31',
+          phone_numbers: ['+16174567890'],
+          emails: ['harrypotter@example.com'],
+          primary_address: {
+            city: 'New York',
+            region: 'NY',
+            street: '4 Privet Drive',
+            postal_code: '11111',
+            country: 'US'
+          }
+        }
       }
-    end
-
-    begin
-      user = client.user_create(Plaid::UserCreateRequest.new(request_data))
+      user = client.user_create(Plaid::UserCreateRequest.new(retry_request_data))
       # Store both user_token and user_id
       user_token = user.user_token if user.user_token
       user_id = user.user_id if user.user_id
       content_type :json
       user.to_hash.to_json
-    rescue Plaid::ApiError => e
-      error_body = JSON.parse(e.response_body) rescue {}
-      if error_body['error_code'] == 'INVALID_FIELD' &&
-         products.any? { |product| product.start_with?("cra_") }
-        retry_request_data = {
-          client_user_id: client_user_id,
-          consumer_report_user_identity: {
-            first_name: 'Harry',
-            last_name: 'Potter',
-            date_of_birth: '1980-07-31',
-            phone_numbers: ['+16174567890'],
-            emails: ['harrypotter@example.com'],
-            primary_address: {
-              city: 'New York',
-              region: 'NY',
-              street: '4 Privet Drive',
-              postal_code: '11111',
-              country: 'US'
-            }
-          }
-        }
-        user = client.user_create(Plaid::UserCreateRequest.new(retry_request_data))
-        # Store both user_token and user_id
-        user_token = user.user_token if user.user_token
-        user_id = user.user_id if user.user_id
-        content_type :json
-        user.to_hash.to_json
-      else
-        raise e
-      end
+    else
+      raise e
     end
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
   end
 end
 
@@ -632,118 +518,103 @@ end
 # - https://plaid.com/docs/payment-initiation/
 # - https://plaid.com/docs/#payment-initiation-create-link-token-request
 post '/api/create_link_token_for_payment' do
-  begin
-    payment_initiation_recipient_create_request = Plaid::PaymentInitiationRecipientCreateRequest.new(
-      {
-        name: 'Bruce Wayne',
-        iban: 'GB33BUKB20201555555555',
-        address: {
-          street: ['686 Bat Cave Lane'],
-          city: 'Gotham',
-          postal_code: '99999',
-          country: 'GB',
-        },
-        bacs: {
-          account: '26207729',
-          sort_code: '560029',
-        }
+  payment_initiation_recipient_create_request = Plaid::PaymentInitiationRecipientCreateRequest.new(
+    {
+      name: 'Bruce Wayne',
+      iban: 'GB33BUKB20201555555555',
+      address: {
+        street: ['686 Bat Cave Lane'],
+        city: 'Gotham',
+        postal_code: '99999',
+        country: 'GB',
+      },
+      bacs: {
+        account: '26207729',
+        sort_code: '560029',
       }
-    )
-    create_recipient_response = client.payment_initiation_recipient_create(
-      payment_initiation_recipient_create_request
-    )
-    recipient_id = create_recipient_response.recipient_id
+    }
+  )
+  create_recipient_response = client.payment_initiation_recipient_create(
+    payment_initiation_recipient_create_request
+  )
+  recipient_id = create_recipient_response.recipient_id
 
-    payment_initiation_recipient_get_request = Plaid::PaymentInitiationRecipientGetRequest.new(
-      {
-        recipient_id: recipient_id
+  payment_initiation_recipient_get_request = Plaid::PaymentInitiationRecipientGetRequest.new(
+    {
+      recipient_id: recipient_id
+    }
+  )
+  get_recipient_response = client.payment_initiation_recipient_get(
+    payment_initiation_recipient_get_request
+  )
+
+  payment_initiation_payment_create_request = Plaid::PaymentInitiationPaymentCreateRequest.new(
+    {
+      recipient_id: recipient_id,
+      reference: 'testpayment',
+      amount: {
+        value: 100.00,
+        currency: 'GBP'
       }
-    )
-    get_recipient_response = client.payment_initiation_recipient_get(
-      payment_initiation_recipient_get_request
-    )
+    }
+  )
+  create_payment_response = client.payment_initiation_payment_create(
+    payment_initiation_payment_create_request
+  )
+  payment_id = create_payment_response.payment_id
 
-    payment_initiation_payment_create_request = Plaid::PaymentInitiationPaymentCreateRequest.new(
-      {
-        recipient_id: recipient_id,
-        reference: 'testpayment',
-        amount: {
-          value: 100.00,
-          currency: 'GBP'
-        }
-      }
-    )
-    create_payment_response = client.payment_initiation_payment_create(
-      payment_initiation_payment_create_request
-    )
-    payment_id = create_payment_response.payment_id
+  link_token_create_request = Plaid::LinkTokenCreateRequest.new(
+    {
+      client_name: 'Plaid Quickstart',
+      user: {
+        # This should correspond to a unique id for the current user.
+        # Typically, this will be a user ID number from your application.
+        # Personally identifiable information, such as an email address or phone number, should not be used here.
+        client_user_id: 'user-id'
+      },
 
-    link_token_create_request = Plaid::LinkTokenCreateRequest.new(
-      {
-        client_name: 'Plaid Quickstart',  
-        user: { 
-          # This should correspond to a unique id for the current user.
-          # Typically, this will be a user ID number from your application.
-          # Personally identifiable information, such as an email address or phone number, should not be used here.
-          client_user_id: 'user-id' 
-        },
-        
-        # Institutions from all listed countries will be shown.
-        country_codes: ENV['PLAID_COUNTRY_CODES'].split(','),
-        language: 'en',
+      # Institutions from all listed countries will be shown.
+      country_codes: ENV['PLAID_COUNTRY_CODES'].split(','),
+      language: 'en',
 
-        # The 'payment_initiation' product has to be the only element in the 'products' list.
-        products: ['payment_initiation'],
-        
-        payment_initiation: { 
-          payment_id: payment_id 
-        },
-        redirect_uri: nil_if_empty_envvar('PLAID_REDIRECT_URI')
-      }
-    )
-    link_response = client.link_token_create(link_token_create_request)
-    pretty_print_response(link_response.to_hash)
-    content_type :json
-    { link_token: link_response.link_token }.to_hash.to_json
-    
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+      # The 'payment_initiation' product has to be the only element in the 'products' list.
+      products: ['payment_initiation'],
+
+      payment_initiation: {
+        payment_id: payment_id
+      },
+      redirect_uri: nil_if_empty_envvar('PLAID_REDIRECT_URI')
+    }
+  )
+  link_response = client.link_token_create(link_token_create_request)
+  pretty_print_response(link_response.to_hash)
+  content_type :json
+  { link_token: link_response.link_token }.to_hash.to_json
 end
 
 # Retrieve CRA Base Report and PDF
 # Base report: https://plaid.com/docs/check/api/#cracheck_reportbase_reportget
 # PDF: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 get '/api/cra/get_base_report' do
-  begin
-    get_response = get_cra_base_report_with_retries(client, user_token, user_id)
-    pretty_print_response(get_response.to_hash)
+  get_response = get_cra_base_report_with_retries(client, user_token, user_id)
+  pretty_print_response(get_response.to_hash)
 
-    # Use user_token if available, otherwise use user_id
-    pdf_params = {}
-    if user_token
-      pdf_params[:user_token] = user_token
-    elsif user_id
-      pdf_params[:user_id] = user_id
-    end
-    pdf_response = client.cra_check_report_pdf_get(
-      Plaid::CraCheckReportPDFGetRequest.new(pdf_params)
-    )
-
-    content_type :json
-    {
-      report: get_response.report.to_hash,
-      pdf: Base64.encode64(File.read(pdf_response))
-    }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
+  # Use user_token if available, otherwise use user_id
+  pdf_params = {}
+  if user_token
+    pdf_params[:user_token] = user_token
+  elsif user_id
+    pdf_params[:user_id] = user_id
   end
+  pdf_response = client.cra_check_report_pdf_get(
+    Plaid::CraCheckReportPDFGetRequest.new(pdf_params)
+  )
+
+  content_type :json
+  {
+    report: get_response.report.to_hash,
+    pdf: Base64.encode64(File.read(pdf_response))
+  }.to_json
 end
 
 def get_cra_base_report_with_retries(plaid_client, user_token, user_id)
@@ -765,32 +636,25 @@ end
 # Income insights: https://plaid.com/docs/check/api/#cracheck_reportincome_insightsget
 # PDF w/ income insights: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 get '/api/cra/get_income_insights' do
-  begin
-    get_response = get_income_insights_with_retries(client, user_token, user_id)
-    pretty_print_response(get_response.to_hash)
+  get_response = get_income_insights_with_retries(client, user_token, user_id)
+  pretty_print_response(get_response.to_hash)
 
-    # Use user_token if available, otherwise use user_id
-    pdf_params = { add_ons: [Plaid::CraPDFAddOns::INCOME_INSIGHTS] }
-    if user_token
-      pdf_params[:user_token] = user_token
-    elsif user_id
-      pdf_params[:user_id] = user_id
-    end
-    pdf_response = client.cra_check_report_pdf_get(
-      Plaid::CraCheckReportPDFGetRequest.new(pdf_params)
-    )
-
-    content_type :json
-    {
-      report: get_response.report.to_hash,
-      pdf: Base64.encode64(File.read(pdf_response))
-    }.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
+  # Use user_token if available, otherwise use user_id
+  pdf_params = { add_ons: [Plaid::CraPDFAddOns::INCOME_INSIGHTS] }
+  if user_token
+    pdf_params[:user_token] = user_token
+  elsif user_id
+    pdf_params[:user_id] = user_id
   end
+  pdf_response = client.cra_check_report_pdf_get(
+    Plaid::CraCheckReportPDFGetRequest.new(pdf_params)
+  )
+
+  content_type :json
+  {
+    report: get_response.report.to_hash,
+    pdf: Base64.encode64(File.read(pdf_response))
+  }.to_json
 end
 
 def get_income_insights_with_retries(plaid_client, user_token, user_id)
@@ -811,18 +675,11 @@ end
 # Retrieve CRA Partner Insights
 # https://plaid.com/docs/check/api/#cracheck_reportpartner_insightsget
 get '/api/cra/get_partner_insights' do
-  begin
-    response = get_check_partner_insights_with_retries(client, user_token, user_id)
-    pretty_print_response(response.to_hash)
+  response = get_check_partner_insights_with_retries(client, user_token, user_id)
+  pretty_print_response(response.to_hash)
 
-    content_type :json
-    response.to_hash.to_json
-  rescue Plaid::ApiError => e
-    error_response = format_error(e)
-    pretty_print_response(error_response)
-    content_type :json
-    error_response.to_json
-  end
+  content_type :json
+  response.to_hash.to_json
 end
 
 def get_check_partner_insights_with_retries(plaid_client, user_token, user_id)
@@ -849,6 +706,9 @@ def poll_with_retries(ms = 1000, retries_left = 20)
   begin
     yield
   rescue Plaid::ApiError => e
+    json_response = JSON.parse(e.response_body)
+    raise e unless json_response['error_code'] == 'PRODUCT_NOT_READY'
+
     if retries_left > 0
       sleep(ms / 1000.0)
       poll_with_retries(ms, retries_left - 1) { yield }
@@ -856,6 +716,13 @@ def poll_with_retries(ms = 1000, retries_left = 20)
       raise 'Ran out of retries while polling'
     end
   end
+end
+
+error Plaid::ApiError do |e|
+  error_response = format_error(e)
+  pretty_print_response(error_response)
+  content_type :json
+  error_response.to_json
 end
 
 def format_error(err)

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -707,7 +707,8 @@ def poll_with_retries(ms = 1000, retries_left = 20)
     yield
   rescue Plaid::ApiError => e
     json_response = JSON.parse(e.response_body)
-    raise e unless json_response['error_code'] == 'PRODUCT_NOT_READY'
+    is_retryable = json_response['error_code'] == 'PRODUCT_NOT_READY' || e.code >= 500
+    raise e unless is_retryable
 
     if retries_left > 0
       sleep(ms / 1000.0)

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -706,8 +706,12 @@ def poll_with_retries(ms = 1000, retries_left = 20)
   begin
     yield
   rescue Plaid::ApiError => e
-    json_response = JSON.parse(e.response_body)
-    is_retryable = json_response['error_code'] == 'PRODUCT_NOT_READY' || e.code >= 500
+    error_code = begin
+      JSON.parse(e.response_body)['error_code']
+    rescue JSON::ParserError
+      nil
+    end
+    is_retryable = error_code == 'PRODUCT_NOT_READY' || e.code >= 500
     raise e unless is_retryable
 
     if retries_left > 0

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -10,6 +10,8 @@ require 'securerandom'
 require 'sinatra'
 
 set :port, ENV['APP_PORT'] || 8000
+set :show_exceptions, false
+set :dump_errors, false
 
 # disable CSRF warning and Rack protection on localhost due to usage of local /api proxy in react app.
 # delete this for a production application.
@@ -723,23 +725,45 @@ def poll_with_retries(ms = 1000, retries_left = 20)
   end
 end
 
-error Plaid::ApiError do |e|
-  error_response = format_error(e)
-  pretty_print_response(error_response)
+post '/api/link_exit_error' do
+  request_body = JSON.parse(request.body.read)
+  puts '[Link Exit Error (frontend)]'
+  pretty_print_response(request_body)
   content_type :json
-  error_response.to_json
+  { status: 'logged' }.to_json
+end
+
+error Plaid::ApiError do |e|
+  begin
+    error_response = format_error(e)
+    pretty_print_response(error_response)
+    status e.code
+    content_type :json
+    error_response.to_json
+  rescue
+    status 500
+    content_type :json
+    { error: { status_code: 500, error_type: 'API_ERROR', error_code: 'INTERNAL_SERVER_ERROR',
+               error_message: 'An unexpected error occurred' } }.to_json
+  end
+end
+
+error do
+  status 500
+  content_type :json
+  {
+    error: {
+      status_code: 500,
+      error_type: 'API_ERROR',
+      error_code: 'INTERNAL_SERVER_ERROR',
+      error_message: 'An unexpected error occurred'
+    }
+  }.to_json
 end
 
 def format_error(err)
   body = JSON.parse(err.response_body)
-  {
-    error: {
-      status_code: err.code,
-      error_code: body['error_code'],
-      error_message: body['error_message'],
-      error_type: body['error_type']
-    }
-  }
+  { error: body.merge('status_code' => err.code) }
 end
 
 def pretty_print_response(response)


### PR DESCRIPTION
## Summary

- **Errors from Link were not surfaced at all.** Errors like INVALID_LINK_CUSTOMIZATION and INSTITUTION_REGISTRATION_REQUIRED come from the Link component (via the `onExit` callback), not from backend API calls. The frontend had no handler for these, so they were silently dropped. These are now displayed in the UI and forwarded to backend logs via a new `/api/link_exit_error` endpoint in each backend.
- **Errors from backend API calls displayed with incorrect or missing information.** Python showed no error message, Ruby showed "UNKNOWN" / "API_ERROR" instead of the real error code and type, and Java was missing user-friendly display messages. Error formatting is now consistent across all backends, matching Node's approach of passing through the full Plaid error body.
- **Error handling was duplicated per-endpoint instead of centralized.** Python, Ruby, and Java each had per-route try/catch blocks. These are replaced with centralized handlers (`@app.errorhandler` in Python, Sinatra `error` blocks in Ruby, `ExceptionMapper` + shared `PlaidApiHelper.callPlaid()` in Java). Java specifically needs the helper pattern because Retrofit doesn't throw on HTTP errors — it returns them as successful responses with error bodies, so each endpoint would otherwise need its own `if (!response.isSuccessful())` boilerplate. The other backends' HTTP clients throw on errors, so a single global handler is sufficient.
- **Polling retry logic was broken or too aggressive.** Some backends retried on all errors instead of only `PRODUCT_NOT_READY`, and none retried on transient 5xx errors. Java's `AssetsResource` had a no-op polling loop. Node's `pollWithRetries` never propagated rejections. All backends now share the same retry policy: retry on `PRODUCT_NOT_READY` or 5xx, fail fast on everything else.
- **Frontend didn't handle non-JSON error responses.** If a backend returned HTML (e.g. Ruby's Sinatra stack trace page, or a proxy 502), `response.json()` threw an unhandled exception. The frontend now checks `response.ok` and gracefully handles parse failures.
- **Go and Node error handlers returned HTTP 200 for all Plaid errors.** The frontend received errors but with a 200 status, masking the actual failure. Both now return the proper HTTP status code from the Plaid error response.
- **Common errors lacked actionable guidance.** The frontend now shows contextual tips for specific error codes — INVALID_LINK_CUSTOMIZATION points to the dashboard Data Transparency settings, and INSTITUTION_REGISTRATION_REQUIRED explains OAuth institution availability timelines.

### Frontend
- Add `onExit` callback to Link component to capture and surface Link errors
- Display Link exit errors in the UI via a warning callout in the header
- Send Link exit errors to the backend (`/api/link_exit_error`) so they appear in server logs as well as the UI
- Add contextual tips for INVALID_LINK_CUSTOMIZATION (dashboard link) and INSTITUTION_REGISTRATION_REQUIRED (OAuth timing guidance)
- Handle both wrapped (`{error: ...}`) and flat error formats in `generateToken`
- Check `response.ok` before calling `response.json()` so non-JSON error responses (e.g. HTML 502) don't throw unhandled exceptions

### Python
- Add `/api/link_exit_error` endpoint to log Link errors on the server
- Fix `format_error` — was mapping `error_message` into `display_message` and omitting `error_message` entirely, so the frontend had nothing to show. Now spreads the full Plaid error body, matching Node's approach.
- Centralize error handling via `@app.errorhandler` instead of per-endpoint try/catch
- Fix 4 endpoints returning raw error bodies without the `{ error: ... }` wrapper the frontend expects
- Harden `poll_with_retries` JSON parsing so a non-JSON 5xx doesn't crash instead of retrying

### Ruby
- Add `/api/link_exit_error` endpoint to log Link errors on the server
- Fix Sinatra's `show_exceptions` middleware replacing JSON error responses with HTML stack trace pages — the frontend couldn't parse the HTML and fell back to hardcoded "UNKNOWN" / "API_ERROR" defaults
- Disable `dump_errors` to stop logging full stack traces for handled errors
- Centralize error handling via Sinatra `error` block instead of per-endpoint rescue
- Add generic catch-all error handler that returns clean JSON
- Add defensive rescue inside the Plaid error handler
- Harden `poll_with_retries` JSON parsing

### Java
- Add `/api/link_exit_error` endpoint to log Link errors on the server
- Fix all endpoints NPE-ing on API errors (Retrofit returns errors in the response, not as exceptions)
- Add `PlaidApiException`, `PlaidApiExceptionMapper`, and shared `PlaidApiHelper.callPlaid()` to centralize error handling. Java needs this pattern because Retrofit doesn't throw on HTTP errors — without it, every endpoint would need its own error-checking boilerplate.
- Add missing `display_message` in error construction
- Fix `AssetsResource` polling loop (had no-op `.equals()` checks that never gated retries)
- Fix `CraResource` to only retry on `PRODUCT_NOT_READY` errors instead of all exceptions

### Node
- Add `/api/link_exit_error` endpoint to log Link errors on the server
- Fix `pollWithRetries` retrying on all errors instead of only `PRODUCT_NOT_READY`
- Fix `pollWithRetries` not propagating rejections up the promise chain
- Fix error middleware returning HTTP 200 for all errors — now returns the actual status code

### Go
- Add `/api/link_exit_error` endpoint to log Link errors on the server
- Fix `pollWithRetries` retrying on all errors instead of only `PRODUCT_NOT_READY`
- Fix `renderError` returning HTTP 200 for all Plaid errors — now returns the actual status code and logs the error

## Test plan

- [ ] Start each backend (Python, Ruby, Java, Node, Go), trigger an API error (e.g. invalid API keys) → verify error_code, error_type, and error_message all display correctly in the frontend
- [ ] Verify error responses return proper HTTP status codes (not 200)
- [ ] Ruby: verify server logs show clean formatted errors without stack traces
- [ ] Java: verify display_message renders in the frontend when available
- [ ] Test Link flow with an institution that triggers an exit error → verify the error is surfaced in the UI with contextual tips and logged on the server
- [ ] Test asset report / CRA polling with transient errors → verify retries work and eventually time out cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: cbe534d1-8262-4037-9c93-a5b9c18dd64a