### PR TITLE
Fix token exchange race condition and relative URL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ const App = () => {
   }, [dispatch]);
 
   const generateUserToken = useCallback(async () => {
-    const response = await fetch("api/create_user_token", { method: "POST" });
+    const response = await fetch("/api/create_user_token", { method: "POST" });
     if (!response.ok) {
       dispatch({ type: "SET_STATE", state: { userToken: null, userId: null } });
       return;

--- a/frontend/src/Components/Link/index.tsx
+++ b/frontend/src/Components/Link/index.tsx
@@ -9,7 +9,7 @@ const Link = () => {
     useContext(Context);
 
   const onSuccess = React.useCallback(
-    (public_token: string) => {
+    async (public_token: string) => {
       // If the access_token is needed, send public_token to server
       const exchangePublicTokenForAccessToken = async () => {
         const response = await fetch("/api/set_access_token", {
@@ -48,7 +48,7 @@ const Link = () => {
         // When only CRA products are enabled, only user_token is needed. access_token/public_token exchange is not needed.
         dispatch({ type: "SET_STATE", state: { isItemAccess: false } });
       } else {
-        exchangePublicTokenForAccessToken();
+        await exchangePublicTokenForAccessToken();
       }
 
       dispatch({ type: "SET_STATE", state: { linkSuccess: true } });


### PR DESCRIPTION
## Summary

- **Await token exchange before navigating**: `onSuccess` was calling `exchangePublicTokenForAccessToken()` without awaiting it, then immediately dispatching `linkSuccess: true`. On slow connections or backend errors, the UI would show the success view before the access token was available, causing all subsequent API calls to fail.
- **Fix relative URL**: `fetch("api/create_user_token")` was missing its leading slash. All other fetch calls use `/api/...`.

## Test plan

- [ ] Complete a Link flow and verify the success view shows the correct `access_token` and `item_id`
- [ ] Simulate a slow backend on `/api/set_access_token` and verify the UI doesn't navigate prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: bd5bab3d-1669-47a1-bd2e-3fa4a399eb6b