### PR TITLE
Fix Identity component CSS import missed in Tailwind migration

### DIFF
--- a/frontend/src/Components/Table/Identity.tsx
+++ b/frontend/src/Components/Table/Identity.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { DataItem, Categories } from "../../dataUtilities";
 
-import styles from "./Identity.module.scss";
+import styles from "./Identity.module.css";
 
 interface Props {
   data: Array<DataItem>;


### PR DESCRIPTION
## Summary
- Fix stray `.scss` → `.css` import in `Identity.tsx` that was missed in the Tailwind CSS migration (c8f8f36)

## Test plan
- [ ] Verify the Identity component renders correctly in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 64920ce4-5a7f-40bf-bc82-01fde6b0f675