### PR TITLE
Fix stale Dashboard navigation path in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ SIGNAL_RULESET_KEY=
 # Request production approval at https://dashboard.plaid.com/overview/production
 # Once approved, you can set your environment to 'production' to test this application against production data. We recommend sticking to `sandbox` for initial development and testing.
 # Some institutions (Chase, Fidelity, Schwab) take longer to get approval for and aren't available immediately.
-# NOTE: To use Production, you must set a use case for Link. 
-# You can do this in the Dashboard under Link -> Link Customization -> Data Transparency: 
+# NOTE: To use Production, you must set a use case for Link.
+# You can do this in the Dashboard under Link -> Customization -> Data Transparency Messaging:
 # https://dashboard.plaid.com/link/data-transparency-v5
 PLAID_ENV=sandbox
 


### PR DESCRIPTION
## Summary
- `.env.example` still referenced the old Dashboard path `Link -> Link Customization -> Data Transparency` for setting a Link use case.
- `README.md` was recently updated (#585) to the current path `Link -> Customization -> Data Transparency Messaging`, but `.env.example` was missed.
- This aligns `.env.example` with README.md so both point to the same, current Dashboard navigation.

## Test plan
- [x] Diffed the change to confirm it only touches comment text in `.env.example`
- N/A functional testing — comment-only doc fix, no code or behavior change