### PR TITLE
Fix CRA and income-paystubs product demos 404ing in the frontend

### DIFF
--- a/frontend/src/Components/ProductTypes/Products.tsx
+++ b/frontend/src/Components/ProductTypes/Products.tsx
@@ -183,7 +183,7 @@ const Products = () => {
 
       {products.includes("income_verification") && (
         <Endpoint
-          endpoint="/income/verification/paystubs"
+          endpoint="income/verification/paystubs"
           name="Income Paystubs"
           categories={incomePaystubsCategories}
           schema="/income/verification/paystubs"
@@ -194,7 +194,7 @@ const Products = () => {
 
       {(products.includes("cra_base_report") || products.includes("cra_income_insights")) && (
         <Endpoint
-          endpoint="/cra/get_base_report"
+          endpoint="cra/get_base_report"
           name="CRA Base Report"
           categories={checkReportBaseReportCategories}
           schema="/cra/check_report/base_report/get"
@@ -205,7 +205,7 @@ const Products = () => {
 
       {(products.includes("cra_base_report") || products.includes("cra_income_insights")) && (
         <Endpoint
-          endpoint="/cra/get_income_insights"
+          endpoint="cra/get_income_insights"
           name="CRA Income Insights"
           categories={checkReportInsightsCategories}
           schema="/cra/check_report/income_insights/get"
@@ -216,7 +216,7 @@ const Products = () => {
 
       {products.includes("cra_partner_insights") && (
         <Endpoint
-          endpoint="/cra/get_partner_insights"
+          endpoint="cra/get_partner_insights"
           name="CRA Partner Insights"
           categories={checkReportPartnerInsightsCategories}
           schema="/cra/check_report/partner_insights/get"


### PR DESCRIPTION
The CRA (`get_base_report`, `get_income_insights`, `get_partner_insights`) and income-paystubs `Endpoint` components passed their path with a leading slash. `Endpoint/index.tsx` builds the request as `/api/${endpoint}`, so a leading slash produces `/api//cra/...` — a double-slash path that Express serves as 404, breaking all four product demos. Every other endpoint passes a bare name (`auth`, `transactions`, …).

Removes the leading slash from the four endpoints so they resolve to the real backend routes (`/api/cra/get_base_report`, `/api/income/verification/paystubs`, etc.).

<!-- Claude Session: 3fd9ad6b-147d-48ee-911d-91f17fd33d29 -->