### PR TITLE
Fix latent bugs and clean up quickstart backends, frontend, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 
+# Optional: override the port the backend server listens on (defaults to 8000). Read by the Node, Ruby, and Go backends.
+# APP_PORT=8000
+
 # SIGNAL_RULESET_KEY is required for both Balance and Signal Transaction Scores
 # Set this to the ruleset_key configured in your Plaid Dashboard at https://dashboard.plaid.com/signal/risk-profiles?environment=sandbox
 # See https://plaid.com/docs/signal/ for more information

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ the dashboard: [https://dashboard.plaid.com/developers/keys](https://dashboard.p
 
 - The language you intend to use is installed on your machine and available at your command line.
   This repo should generally work with active LTS versions of each language such as node >= 18,
-  python >= 3.8, ruby >= 2.6, etc.
+  python >= 3.9, ruby >= 3.0, etc.
 - Your environment variables populated in `.env`
 - [npm](https://www.npmjs.com/get-npm)
 - If using Windows, a command line utility capable of running basic Unix shell commands

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,9 +115,11 @@ const App = () => {
           return;
         }
         dispatch({ type: "SET_STATE", state: { linkToken: data.link_token } });
+        // Save the link_token to be used later in the Oauth flow.
+        if (typeof data.link_token === "string") {
+          localStorage.setItem("link_token", data.link_token);
+        }
       }
-      // Save the link_token to be used later in the Oauth flow.
-      localStorage.setItem("link_token", data.link_token);
     },
     [dispatch]
   );

--- a/frontend/src/Components/Link/index.tsx
+++ b/frontend/src/Components/Link/index.tsx
@@ -88,8 +88,6 @@ const Link = () => {
   };
 
   if (window.location.href.includes("?oauth_state_id=")) {
-    // TODO: figure out how to delete this ts-ignore
-    // @ts-ignore
     config.receivedRedirectUri = window.location.href;
     isOauth = true;
   }

--- a/frontend/src/dataUtilities.ts
+++ b/frontend/src/dataUtilities.ts
@@ -120,6 +120,7 @@ interface TransferDataItem {
   type: string;
   achClass: string | null;
   network: string;
+  status: string;
 }
 
 interface TransferAuthorizationDataItem {

--- a/go/server.go
+++ b/go/server.go
@@ -41,7 +41,7 @@ func init() {
 	// load env vars from .env file
 	err := godotenv.Load()
 	if err != nil {
-		fmt.Println("Error when loading environment variables from .env file %w", err)
+		fmt.Printf("Error when loading environment variables from .env file: %v\n", err)
 	}
 
 	// set constants from env
@@ -71,12 +71,6 @@ func init() {
 	}
 	if APP_PORT == "" {
 		APP_PORT = "8000"
-	}
-	if PLAID_CLIENT_ID == "" {
-		log.Fatal("PLAID_CLIENT_ID is not set. Make sure to fill out the .env file")
-	}
-	if PLAID_SECRET == "" {
-		log.Fatal("PLAID_SECRET is not set. Make sure to fill out the .env file")
 	}
 
 	// create Plaid client
@@ -364,6 +358,8 @@ func transactions(c *gin.Context) {
 	var modified []plaid.Transaction
 	var removed []plaid.RemovedTransaction // Removed transaction ids
 	hasMore := true
+	const maxSyncPolls = 10
+	syncPolls := 0
 	// Iterate through each page of new transaction updates for item
 	for hasMore {
 		request := plaid.NewTransactionsSyncRequest(accessToken)
@@ -389,6 +385,11 @@ func transactions(c *gin.Context) {
 		// https://github.com/plaid/pattern
 
 		if *cursor == "" {
+			syncPolls++
+			if syncPolls >= maxSyncPolls {
+				renderError(c, fmt.Errorf("timed out waiting for transactions to become available after %d polls", maxSyncPolls))
+				return
+			}
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -450,8 +451,20 @@ func transferAuthorize(c *gin.Context) {
 
 	accountID = accountsGetResp.GetAccounts()[0].AccountId
 	transferType, err := plaid.NewTransferTypeFromValue("debit")
+	if err != nil {
+		renderError(c, err)
+		return
+	}
 	transferNetwork, err := plaid.NewTransferNetworkFromValue("ach")
+	if err != nil {
+		renderError(c, err)
+		return
+	}
 	ACHClass, err := plaid.NewACHClassFromValue("ppd")
+	if err != nil {
+		renderError(c, err)
+		return
+	}
 
 	transferAuthorizationCreateUser := plaid.NewTransferAuthorizationUserInRequest("FirstName LastName")
 	transferAuthorizationCreateRequest := plaid.NewTransferAuthorizationCreateRequest(
@@ -844,7 +857,17 @@ func statements(c *gin.Context) {
 	statementsListResp, _, err := client.PlaidApi.StatementsList(ctx).StatementsListRequest(
 		*plaid.NewStatementsListRequest(accessToken),
 	).Execute()
-	statementId := statementsListResp.GetAccounts()[0].GetStatements()[0].StatementId
+	if err != nil {
+		renderError(c, err)
+		return
+	}
+
+	accounts := statementsListResp.GetAccounts()
+	if len(accounts) == 0 || len(accounts[0].GetStatements()) == 0 {
+		renderError(c, fmt.Errorf("no statements available for this item"))
+		return
+	}
+	statementId := accounts[0].GetStatements()[0].StatementId
 
 	statementsDownloadResp, _, err := client.PlaidApi.StatementsDownload(ctx).StatementsDownloadRequest(
 		*plaid.NewStatementsDownloadRequest(accessToken, statementId),

--- a/node/index.js
+++ b/node/index.js
@@ -6,7 +6,6 @@ const { Configuration, PlaidApi, Products, PlaidEnvironments, CraCheckReportProd
 const util = require('util');
 const { v4: uuidv4 } = require('uuid');
 const express = require('express');
-const bodyParser = require('body-parser');
 const moment = require('moment');
 const cors = require('cors');
 
@@ -82,11 +81,11 @@ const client = new PlaidApi(configuration);
 
 const app = express();
 app.use(
-  bodyParser.urlencoded({
+  express.urlencoded({
     extended: false,
   }),
 );
-app.use(bodyParser.json());
+app.use(express.json());
 app.use(cors());
 
 app.post('/api/info', function (request, response, next) {
@@ -646,7 +645,9 @@ const getAssetReportWithRetries = (
   return pollWithRetries(
     async () => {
       return await plaidClient.assetReportGet(request);
-    }
+    },
+    ms,
+    retriesLeft,
   );
 }
 

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,6 @@
   "repository": "https://github.com/plaid/quickstart",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.20.4",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.22.1",

--- a/python/server.py
+++ b/python/server.py
@@ -197,7 +197,7 @@ def create_link_token_for_payment():
         )
     )
 
-    if PLAID_REDIRECT_URI!=None:
+    if PLAID_REDIRECT_URI is not None:
         linkRequest['redirect_uri']=PLAID_REDIRECT_URI
     linkResponse = client.link_token_create(linkRequest)
     pretty_print_response(linkResponse.to_dict())
@@ -232,7 +232,7 @@ def create_link_token():
             )
         )
 
-    if PLAID_REDIRECT_URI!=None:
+    if PLAID_REDIRECT_URI is not None:
         request['redirect_uri']=PLAID_REDIRECT_URI
     if Products('statements') in products:
         statements=LinkTokenCreateRequestStatements(
@@ -668,6 +668,8 @@ def item():
 # PDF: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 @app.route('/api/cra/get_base_report', methods=['GET'])
 def cra_check_report():
+    if not user_token and not user_id:
+        return jsonify({'error': 'You must call /api/create_user_token first'}), 400
     # Use user_token if available, otherwise use user_id
     if user_token:
         base_report_request = CraCheckReportBaseReportGetRequest(user_token=user_token, item_ids=[])
@@ -694,6 +696,8 @@ def cra_check_report():
 # PDF w/ income insights: https://plaid.com/docs/check/api/#cracheck_reportpdfget
 @app.route('/api/cra/get_income_insights', methods=['GET'])
 def cra_income_insights():
+    if not user_token and not user_id:
+        return jsonify({'error': 'You must call /api/create_user_token first'}), 400
     # Use user_token if available, otherwise use user_id
     insights_request = {}
     if user_token:
@@ -721,6 +725,8 @@ def cra_income_insights():
 # https://plaid.com/docs/check/api/#cracheck_reportpartner_insightsget
 @app.route('/api/cra/get_partner_insights', methods=['GET'])
 def cra_partner_insights():
+    if not user_token and not user_id:
+        return jsonify({'error': 'You must call /api/create_user_token first'}), 400
     # Use user_token if available, otherwise use user_id
     if user_token:
         partner_request = CraCheckReportPartnerInsightsGetRequest(user_token=user_token)
@@ -750,11 +756,10 @@ def poll_with_retries(request_callback, ms=1000, retries_left=20):
             is_retryable = error_code == 'PRODUCT_NOT_READY' or e.status >= 500
             if not is_retryable:
                 raise e
-            elif retries_left == 0:
-                raise Exception('Ran out of retries while polling') from e
             else:
                 retries_left -= 1
                 time.sleep(ms / 1000)
+    raise Exception('Ran out of retries while polling')
 
 def pretty_print_response(response):
   print(json.dumps(response, indent=2, sort_keys=True, default=str))

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -116,7 +116,7 @@ get '/api/transactions' do
   end
   # Return the 8 most recent transactions
   content_type :json
-  { latest_transactions: added.sort_by(&:date).last(8).map(&:to_hash) }.to_json
+  { latest_transactions: added.sort_by { |t| t.date || Date.new(0) }.last(8).map(&:to_hash) }.to_json
 end
 
 # Retrieve ACH or ETF account numbers for an Item
@@ -241,7 +241,7 @@ get '/api/assets' do
     content_type :json
     return {
       error: {
-        error_code: 0,
+        error_code: 'ASSET_REPORT_TIMED_OUT',
         error_message: 'Timed out when polling for Asset Report'
       }
     }.to_json
@@ -284,7 +284,7 @@ get '/api/item' do
   institutions_get_by_id_request = Plaid::InstitutionsGetByIdRequest.new(
     {
       institution_id: item_response.item.institution_id,
-      country_codes: ['US']
+      country_codes: ENV['PLAID_COUNTRY_CODES'].split(',')
     }
   )
   institution_response =
@@ -504,7 +504,6 @@ end
 
 def nil_if_empty_envvar(field)
   val = ENV[field]
-  puts "val #{val}"
   if !val.nil? && val.length > 0
     return val
   else


### PR DESCRIPTION
Fixes a set of issues found in a review of the quickstart. None change the sandbox happy path, but several are real bugs a developer copying this template would inherit. (The separate CRA/income endpoint 404 fix is #596.)

Correctness:
- **Python** `poll_with_retries` returned `None` when retries were exhausted (the `elif retries_left == 0` was dead code), so callers hit a confusing `AttributeError` instead of a clear timeout — now raises. CRA handlers also 400 cleanly if called before a user token exists (previously `UnboundLocalError`).
- **Go** `statements` handler ignored the `StatementsList` error and indexed `[0]` on possibly-empty slices (server panic); transfer constructor errors were discarded; the transactions-sync poll loop could spin forever — all now checked/bounded.

Hygiene:
- Drop the redundant `body-parser` dependency in Node (Express bundles `express.json()`/`urlencoded()`).
- Go: remove an unreachable duplicate env-check block and fix a `%w` verb passed to `Println`.
- Ruby: remove a stray `puts` debug line and use the configured `PLAID_COUNTRY_CODES` instead of a hardcoded `['US']`.
- Frontend: remove an unnecessary `@ts-ignore` on `receivedRedirectUri` and only persist `link_token` when a real token is returned.
- Docs: correct the README's EOL Python/Ruby minimums to match what the manifests require, and document the `APP_PORT` override in `.env.example`.

<!-- Claude Session: 3fd9ad6b-147d-48ee-911d-91f17fd33d29 -->