### PR TITLE
Fix minor bugs surfaced by a quickstart audit

### DIFF
--- a/frontend/src/dataUtilities.ts
+++ b/frontend/src/dataUtilities.ts
@@ -588,7 +588,7 @@ export const transformAuthData = (data: AuthGetResponse) => {
 };
 
 export const transformStatementsData = (data: {json: StatementsListResponse}) => {
-  const account = data.json.accounts[0];
+  const account = data.json.accounts.find((a) => (a.statements ?? []).length > 0);
   if (account == null) {
     return [];
   }

--- a/frontend/src/dataUtilities.ts
+++ b/frontend/src/dataUtilities.ts
@@ -588,12 +588,14 @@ export const transformAuthData = (data: AuthGetResponse) => {
 };
 
 export const transformStatementsData = (data: {json: StatementsListResponse}) => {
-  const account = data.json.accounts[0]!.account_name;
-  const statements = data.json.accounts[0]!.statements;
-  return statements!.map((s) => {
+  const account = data.json.accounts[0];
+  if (account == null) {
+    return [];
+  }
+  return (account.statements ?? []).map((s) => {
     const item: DataItem = {
       date: Intl.DateTimeFormat('en', { month: 'long', year:'numeric' }).format(new Date(s.year!, s.month!)),
-      account: account,
+      account: account.account_name,
     };
     return item;
   });

--- a/go/server.go
+++ b/go/server.go
@@ -862,12 +862,20 @@ func statements(c *gin.Context) {
 		return
 	}
 
-	accounts := statementsListResp.GetAccounts()
-	if len(accounts) == 0 || len(accounts[0].GetStatements()) == 0 {
-		renderError(c, fmt.Errorf("no statements available for this item"))
+	var statementId string
+	for _, account := range statementsListResp.GetAccounts() {
+		if len(account.GetStatements()) > 0 {
+			statementId = account.GetStatements()[0].StatementId
+			break
+		}
+	}
+	if statementId == "" {
+		c.JSON(http.StatusOK, gin.H{
+			"json": statementsListResp,
+			"pdf":  nil,
+		})
 		return
 	}
-	statementId := accounts[0].GetStatements()[0].StatementId
 
 	statementsDownloadResp, _, err := client.PlaidApi.StatementsDownload(ctx).StatementsDownloadRequest(
 		*plaid.NewStatementsDownloadRequest(accessToken, statementId),

--- a/java/src/main/java/com/plaid/quickstart/resources/LinkTokenResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/LinkTokenResource.java
@@ -30,8 +30,6 @@ public class LinkTokenResource {
   private final List<String> plaidProducts;
   private final List<String> countryCodes;
   private final String redirectUri;
-  private final List<Products> correctedPlaidProducts;
-  private final List<CountryCode> correctedCountryCodes;
 
   public LinkTokenResource(PlaidApi plaidClient, List<String> plaidProducts,
     List<String> countryCodes, String redirectUri) {
@@ -39,8 +37,6 @@ public class LinkTokenResource {
     this.plaidProducts = plaidProducts;
     this.countryCodes = countryCodes;
     this.redirectUri = redirectUri;
-    this.correctedPlaidProducts = new ArrayList<>();
-    this.correctedCountryCodes = new ArrayList<>();
   }
 
   public static class LinkToken {
@@ -59,24 +55,26 @@ public class LinkTokenResource {
     LinkTokenCreateRequestUser user = new LinkTokenCreateRequestUser()
 		.clientUserId(clientUserId);
 
+    List<Products> correctedPlaidProducts = new ArrayList<>();
     for (int i = 0; i < this.plaidProducts.size(); i++){
-      this.correctedPlaidProducts.add(Products.fromValue(this.plaidProducts.get(i)));
-    };
+      correctedPlaidProducts.add(Products.fromValue(this.plaidProducts.get(i)));
+    }
 
+    List<CountryCode> correctedCountryCodes = new ArrayList<>();
     for (int i = 0; i < this.countryCodes.size(); i++){
-      this.correctedCountryCodes.add(CountryCode.fromValue(this.countryCodes.get(i)));
-    };
+      correctedCountryCodes.add(CountryCode.fromValue(this.countryCodes.get(i)));
+    }
 
 
 		LinkTokenCreateRequest request = new LinkTokenCreateRequest()
 			.user(user)
 			.clientName("Quickstart Client")
-			.products(this.correctedPlaidProducts)
-			.countryCodes(this.correctedCountryCodes)
+			.products(correctedPlaidProducts)
+			.countryCodes(correctedCountryCodes)
 			.language("en")
       .redirectUri(this.redirectUri);
 
-    if (this.correctedPlaidProducts.contains(Products.STATEMENTS)) {
+    if (correctedPlaidProducts.contains(Products.STATEMENTS)) {
       LinkTokenCreateRequestStatements statementsConfig = new LinkTokenCreateRequestStatements()
         .startDate(LocalDate.now().minusDays(30))
         .endDate(LocalDate.now());

--- a/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/StatementsResource.java
@@ -38,17 +38,30 @@ public class StatementsResource {
     StatementsListResponse statementsListResponseBody = PlaidApiHelper.callPlaid(
       plaidClient.statementsList(statementsListRequest));
 
+    Map<String, Object> responseMap = new HashMap<>();
+    responseMap.put("json", statementsListResponseBody);
+
+    String statementId = null;
+    for (int i = 0; i < statementsListResponseBody.getAccounts().size(); i++) {
+      if (!statementsListResponseBody.getAccounts().get(i).getStatements().isEmpty()) {
+        statementId = statementsListResponseBody.getAccounts().get(i).getStatements().get(0).getStatementId();
+        break;
+      }
+    }
+
+    if (statementId == null) {
+      responseMap.put("pdf", null);
+      return responseMap;
+    }
+
     StatementsDownloadRequest statementsDownloadRequest = new StatementsDownloadRequest()
       .accessToken(QuickstartApplication.accessToken)
-      .statementId(statementsListResponseBody.getAccounts().get(0).getStatements().get(0).getStatementId());
+      .statementId(statementId);
 
     ResponseBody statementsDownloadResponseBody = PlaidApiHelper.callPlaid(
       plaidClient.statementsDownload(statementsDownloadRequest));
 
     String pdf = Base64.getEncoder().encodeToString(statementsDownloadResponseBody.bytes());
-
-    Map<String, Object> responseMap = new HashMap<>();
-    responseMap.put("json", statementsListResponseBody);
     responseMap.put("pdf", pdf);
 
     return responseMap;

--- a/node/index.js
+++ b/node/index.js
@@ -574,9 +574,16 @@ app.get('/api/statements', function (request, response, next) {
     .then(async function () {
       const statementsListResponse = await client.statementsList({ access_token: ACCESS_TOKEN });
       prettyPrintResponse(statementsListResponse);
+      const accountWithStatement = statementsListResponse.data.accounts.find(
+        (account) => account.statements.length > 0
+      );
+      if (!accountWithStatement) {
+        response.json({ json: statementsListResponse.data, pdf: null });
+        return;
+      }
       const pdfRequest = {
         access_token: ACCESS_TOKEN,
-        statement_id: statementsListResponse.data.accounts[0].statements[0].statement_id
+        statement_id: accountWithStatement.statements[0].statement_id
       };
 
       const statementsDownloadResponse = await client.statementsDownload(pdfRequest, {
@@ -653,7 +660,7 @@ const getAssetReportWithRetries = (
 
 const formatError = (error) => {
   return {
-    error: { ...error.data, status_code: error.status },
+    error: { ...error?.data, status_code: error?.status },
   };
 };
 

--- a/python/server.py
+++ b/python/server.py
@@ -593,9 +593,15 @@ def statements():
     request = StatementsListRequest(access_token=access_token)
     response = client.statements_list(request)
     pretty_print_response(response.to_dict())
+    account_with_statement = next(
+        (account for account in response['accounts'] if account['statements']),
+        None
+    )
+    if account_with_statement is None:
+        return jsonify({'error': None, 'json': response.to_dict(), 'pdf': None})
     request = StatementsDownloadRequest(
         access_token=access_token,
-        statement_id=response['accounts'][0]['statements'][0]['statement_id']
+        statement_id=account_with_statement['statements'][0]['statement_id']
     )
     pdf = client.statements_download(request)
     return jsonify({

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -265,7 +265,13 @@ get '/api/statements' do
     client.statements_list(statements_list_request)
   pretty_print_response(statements_list_response.to_hash)
 
-  statement_id = statements_list_response.accounts[0].statements[0].statement_id
+  statement_account = statements_list_response.accounts.find { |account| !account.statements.empty? }
+  if statement_account.nil?
+    content_type :json
+    return { json: statements_list_response.to_hash, pdf: nil }.to_json
+  end
+
+  statement_id = statement_account.statements[0].statement_id
   statements_download_request = Plaid::StatementsDownloadRequest.new({ access_token: access_token, statement_id: statement_id })
   statement_pdf = client.statements_download(statements_download_request)
 


### PR DESCRIPTION
Fixes three latent bugs found while auditing the quickstart — the first two are invisible in Sandbox (which returns clean, complete data) but reachable against real Items.

- `/statements` indexed `accounts[0].statements[0]` unconditionally, so a supported Item whose first account has no statement available in the requested window (e.g. a too-narrow date range) returned a 500 instead of a result. All five backends (node, python, ruby, java, go) and the frontend now select the first account that actually has statements, and return `pdf: null` / an empty table when none do. Go previously `renderError`d on this case and only inspected `accounts[0]`; it now matches the others.
- node: `formatError` threw a `TypeError` when the `/api` error middleware handled a non-Plaid error (e.g. the poll helper rejecting after running out of retries), which masked the original error. Made it null-safe.
- java: `LinkTokenResource` built its corrected product/country lists in singleton instance fields and appended to them on every request, so a second `create_link_token` call (e.g. a browser refresh) sent duplicated products to Plaid. Made them method-local.

Manually exercised the empty-result and error branches (no automated coverage exists for them): the real frontend `transformStatementsData` returns the correct account's rows (or `[]`) including the multi-account case where a later account holds the statement; the Ruby route returns `pdf: null` on empty; `formatError(undefined)` no longer throws; and the node/python guards select the first account with a statement.

<!-- Claude Session: b1aca99f-e497-48b4-80cb-d03b7ec66d8c -->