### PR TITLE
Upgrade react-plaid-link to 5.0.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "immer": "^11.1.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-plaid-link": "^4.1.1",
+        "react-plaid-link": "^5.0.0",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -1558,9 +1558,9 @@
       "license": "MIT"
     },
     "node_modules/react-plaid-link": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
-      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-5.0.0.tgz",
+      "integrity": "sha512-DZ/6C7hf+xhEIG9ElCqjk1lty/z+y+wQuV/A29EUx4fxiPLPe7CXN811C3MrCzI7grV45LD7NRS0Do0ma8KIBg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "immer": "^11.1.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-plaid-link": "^4.1.1",
+    "react-plaid-link": "^5.0.0",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/frontend/src/Components/Link/index.tsx
+++ b/frontend/src/Components/Link/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from "react";
-import { usePlaidLink } from "react-plaid-link";
+import { usePlaidLink, PlaidLinkOptionsWithLinkToken } from "react-plaid-link";
 
 import Context from "../../Context";
 
@@ -32,7 +32,7 @@ const Link = () => {
   );
 
   const onSuccess = React.useCallback(
-    async (public_token: string) => {
+    async (public_token: string | null) => {
       // If the access_token is needed, send public_token to server
       const exchangePublicTokenForAccessToken = async () => {
         const response = await fetch("/api/set_access_token", {
@@ -81,8 +81,8 @@ const Link = () => {
   );
 
   let isOauth = false;
-  const config: Parameters<typeof usePlaidLink>[0] = {
-    token: linkToken!,
+  const config: PlaidLinkOptionsWithLinkToken = {
+    token: linkToken,
     onSuccess,
     onExit,
   };


### PR DESCRIPTION
5.0.0 corrects the public TypeScript definitions to match the Link Web SDK, so this is a types-only upgrade — runtime behavior is unchanged. Two of the corrected definitions reach this app:

- `onSuccess` now types `public_token` as `string | null`, so the callback signature widens to match. The exchange body interpolates the token, which accepts the wider type, so no new branch is needed — the products this sample enables always produce a token when they reach the exchange.
- `receivedRedirectUri` now lives only on `PlaidLinkOptionsWithLinkToken`, not on the `PlaidLinkOptions` union, so assigning it to a union-typed config no longer compiles. `config` is typed as that member directly, which also lets `token` drop its non-null assertion since the member accepts `string | null`.