### PR TITLE
Fix misspelled Java CRA resource method names

### DIFF
--- a/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
+++ b/java/src/main/java/com/plaid/quickstart/resources/CraResource.java
@@ -80,7 +80,7 @@ public class CraResource {
   // https://plaid.com/docs/check/api/#cracheck_reportpdfget
   @GET
   @Path("/get_income_insights")
-  public Map getIncomeInsigts() throws IOException {
+  public Map getIncomeInsights() throws IOException {
     CraCheckReportIncomeInsightsGetRequest request = new CraCheckReportIncomeInsightsGetRequest();
     // Use user_token if available, otherwise use user_id
     if (QuickstartApplication.userToken != null) {
@@ -114,7 +114,7 @@ public class CraResource {
   // https://plaid.com/docs/check/api/#cracheck_reportpartner_insightsget
   @GET
   @Path("/get_partner_insights")
-  public CraCheckReportPartnerInsightsGetResponse getPartnerInsigts() throws IOException {
+  public CraCheckReportPartnerInsightsGetResponse getPartnerInsights() throws IOException {
     CraCheckReportPartnerInsightsGetRequest request = new CraCheckReportPartnerInsightsGetRequest();
     // Use user_token if available, otherwise use user_id
     if (QuickstartApplication.userToken != null) {


### PR DESCRIPTION
\`getIncomeInsigts\` and \`getPartnerInsigts\` in \`CraResource.java\` were both missing the 'h' in Insights. The \`@Path\` route strings and the equivalent method names in the other language backends were already spelled correctly — only the Java method identifiers were wrong.

<!-- Claude Session: b864859c-060c-4979-9ea3-c33011a31563 -->